### PR TITLE
New configuration mode, assist changes etc

### DIFF
--- a/EBike_wireless_remote/documentation/configuration.md
+++ b/EBike_wireless_remote/documentation/configuration.md
@@ -34,7 +34,6 @@ The LED will continue a visual cycle spanning 2 seconds when the button is held 
 
 - __RED LED__ (0n for 0.5 seconds) - ANT+ LEV active
 - __GREEN LED__ (0n for 0.5 seconds) - ANT+ CONTROLS active
-- __BLUE LED__ (0n for 0.5 seconds) - brake control active
 - __ALL LEDs OFF__ for 0.5 seconds
 - (__repeat__ while button is pressed)
 

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -1,18 +1,5 @@
 # Remote operation
-## LED Signalling (Normal mode)
-------
-
-1. ANT Searching/Connection
-   When the remote is searching for either an ANT+ LEV or an ANT+ Controls connection, the **RED LED** will slowly flash. When a connection is made, the **RED LED** will quickly flash and then go out.
-2.  The **GREEN LED** will flash once briefly when the [**PLUS**] or [**MINUS**] keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the [**PLUS**] or [**MINUS**] keys key will cause the led to briefly flash **RED** multiple times to indicate the limit has been reached. 
-3.  If the motor is off, pressing the [**PLUS**] or [**MINUS**] keys will cause a **RED** LED to flash.
-4. The **RED LED** will briefly flash to indicate a long press has been made
-5. The **RED LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
-6. The **BLUE LED** will turn on for 2 seconds to indicated bluetooth mode is active.
-7. A long press of the [**ENTER**] key can be used to determine the configuration options. [See Configuration Options](configuration.md)
-8. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
-9. Motor error states are indicated by the **GREEN LED** on the other side of the Nordic board. motor initialization errors are indicated by a slowly flashing LED, firmware mismatch errors are indicated by a fast flashing LED, and configuration errors are indicated by a steady on LED.
-## LED Signalling (Configuration mode)
+The remote has two operating modes, **NORMAL** **mode** which is the usual mode of operation, and **CONFIGURATION** **mode**, which is used to set various remote options described below. Pressing the **ENTER** key for more than 5 seconds will toggle between the two modes.
 
 ## Short Press buttons (Normal Mode)
 ----
@@ -24,23 +11,33 @@
 ## Long Press Buttons (Normal Mode)
 -----
 * Long Press the [**POWER**] button to turn on/off the motor. See LED Operation Signalling above for a description of operation.
-* Long Press the [**PLUS**] button to pageup on a garmin bike computer
-* Long Press the [**MINUS**] button to pagedown on a garmin bike computer
-* Long press the [**ENTER**] button to page down on a connected gaarmin bike computer
-* to cycle through the configuration LED display.     [See Configuration Options](configuration.md)
-* Long Press both the [**ENTER**] + [**POWER**] buttons at the same time for 10 seconds or longer to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
-* Long press the [**PLUS**] + [**POWER**] buttons to start bluetooth to allow the [Configuration Options](configuration.md)  to be set. 
-* Long press the [**MINUS**] + [**POWER**] buttons to stop bluetooth to save power. 
+* Long Press the [**ENTER**] button to pagedown on a garmin bike computer
 * Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode
 
 
-## Short Press buttons (Normal Mode)
+## Short Press buttons (Configuration Mode)
+1. a short press of the [**ENTER**] key will cycle through the configuration LED display. A **RED LED** indicates support for ANT LEV ebikes, while a to cycle through the configuration LED display. [See Configuration Options](configuration.md) 
+
 ## Long Press buttons (Configuration Mode)
-Bluetooth will also automatically turn off after:
-    * 5 minutes if you left bluetooth running
-    * After you change any [Configuration Options](configuration.md) 
-      (See Configuration Options below)
- 
+* Long Press  the [**POWER**] button to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
+* Long press the [**PLUS**] button to enable support for a connected garmin bike computer
+* Long press the [**MINUS**] button to disable support for a connected garmin bike computer
+* Long press the [**ENTER**] button to leave configuration mode and returrn to normal operation mode for the remote. Configuration mode will also automatically turn off if no keys are pressed for 5 minutes.
+ ## LED Signalling (Normal mode)
+------
+
+1. ANT Searching/Connection
+   When the remote is searching for either an ANT+ LEV or an ANT+ Controls connection, the **RED LED** will slowly flash. When a connection is made, the **RED LED** will quickly flash and then go out.
+2.  The **GREEN LED** will flash once briefly when the [**PLUS**] or [**MINUS**] keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the [**PLUS**] or [**MINUS**] keys key will cause the led to briefly flash **RED** multiple times to indicate the limit has been reached. 
+3.  If the motor is off, pressing the [**PLUS**] or [**MINUS**] keys will cause a **RED** LED to flash. The assist level will NOT change with the motor off. 
+4. The **RED LED** will briefly flash to indicate a long press has been made
+5. A very long press (> 5 seconds) of the [**ENTER**] key will flash the BLUE LED for 2 seconds when entering the configuration mode.
+6. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
+
+## LED Signalling (Configuration mode)
+1. The **BLUE LED** will flash for 2 seconds to indicated configuration mode is active.
+2. The **OFF-WHITE LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
+3.  A short press of the ENTER key will display the current remote configuration[See Configuration Options](configuration.md)
 See controlling a Garmin 1030 bike computer for assist levels and page control using a simulated ANT+ LEV Ebike in this video:
 
 [![video](https://img.youtube.com/vi/s7URIMVzcwc/hqdefault.jpg)](https://www.youtube.com/watch?v=s7URIMVzcwc)

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -1,29 +1,28 @@
 # Remote operation
-The remote has two operating modes, **NORMAL** **mode** which is the usual mode of operation, and **CONFIGURATION** **mode**, which is used to set various remote options described below. Pressing the **ENTER** key for more than 5 seconds will toggle between the two modes.
+The remote has two operating modes, **NORMAL** **MODE** which is the usual mode of operation, and **CONFIGURATION** **MODE**, which is used to set various remote operating options described below. Pressing the **ENTER** key for a long press of more than 5 seconds will toggle between NORMAL MODE and CONFIGURATION MODE.
 
-## Short Press buttons (Normal Mode)
+## Button Operation (NORMAL MODE)
 ----
-* Short Press the [**POWER**] button to display the motor battery state of charge. 
-* Short Press the [**ENTER**] button to page up on a connected garmin bike computer
-* Short press the [**PLUS**] button to increase the motor assist level (ANT+ LEV control)
-* Short press the [**MINUS**] button to decrease the motor assist level (ANT+ LEV control)
+* Short Press the [**POWER**] button to display the motor battery state of charge. (works **ONLY** if the motor is ON.)
+*  Long Press the [**POWER**] button to turn on/off the motor. See **LED Signalling** below for a description of operation.
+* Short Press the [**ENTER**] button to **PAGE UP** on a connected garmin bike computer. 
+* Long Press the [**ENTER**] button to **PAGE DOWN** on a garmin bike computer. (Works **ONLY** if garmin control is activated)
+* Short press the [**PLUS**] button to increase the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
+* Short press the [**MINUS**] button to decrease the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
+* Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode.
   
-## Long Press Buttons (Normal Mode)
 -----
-* Long Press the [**POWER**] button to turn on/off the motor. See LED Operation Signalling above for a description of operation.
-* Long Press the [**ENTER**] button to pagedown on a garmin bike computer
-* Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode
 
-
-## Short Press buttons (Configuration Mode)
-1. a short press of the [**ENTER**] key will cycle through the configuration LED display. A **RED LED** indicates support for ANT LEV ebikes, while a to cycle through the configuration LED display. [See Configuration Options](configuration.md) 
-
-## Long Press buttons (Configuration Mode)
-* Long Press  the [**POWER**] button to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
-* Long press the [**PLUS**] button to enable support for a connected garmin bike computer
-* Long press the [**MINUS**] button to disable support for a connected garmin bike computer
-* Long press the [**ENTER**] button to leave configuration mode and returrn to normal operation mode for the remote. Configuration mode will also automatically turn off if no keys are pressed for 5 minutes.
- ## LED Signalling (Normal mode)
+## Button Operation (CONFIGURATION MODE)
+* a short press of the [**ENTER**] key will cycle through the configuration LED display. A **RED LED** indicates support for ANT LEV ebikes, while a BLUE LED indicated support for Garmin bike computers. [See Configuration Options](configuration.md)
+* A Long press the [**ENTER**] button will exit **CONFIGURATION MODE** and return to **NORMAL MODE** . **CONFIGURATION MODE** will also automatically turn off if no keys are pressed for 5 minutes. 
+* Long Press the [**POWER**] button to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
+* Short press the [**PLUS**] button to enable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
+* Short press the [**MINUS**] button to disable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
+* Short press the [**PLUS**] button to enable support for Garmin bike computers.
+* Short press the [**MINUS**] button to disable support for Garmin bike computers.
+  
+## LED Signalling (Normal mode)
 ------
 
 1. ANT Searching/Connection
@@ -38,6 +37,8 @@ The remote has two operating modes, **NORMAL** **mode** which is the usual mode 
 1. The **BLUE LED** will flash for 2 seconds to indicated configuration mode is active.
 2. The **OFF-WHITE LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
 3.  A short press of the ENTER key will display the current remote configuration[See Configuration Options](configuration.md)
+
+
 See controlling a Garmin 1030 bike computer for assist levels and page control using a simulated ANT+ LEV Ebike in this video:
 
 [![video](https://img.youtube.com/vi/s7URIMVzcwc/hqdefault.jpg)](https://www.youtube.com/watch?v=s7URIMVzcwc)

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -1,35 +1,41 @@
 # Remote operation
-## LED Signalling
+## LED Signalling (Normal mode)
 ------
+
 1. ANT Searching/Connection
    When the remote is searching for either an ANT+ LEV or an ANT+ Controls connection, the **RED LED** will slowly flash. When a connection is made, the **RED LED** will quickly flash and then go out.
-2.  The **GREEN LED** will flash once briefly when the [**PLUS**] or [**MINUS**] keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the [**PLUS**] or [**MINUS**] keys key will cause the led to briefly flash multiple times to indicate the limit has been reached. If the motor is on, the color of this LED will be **RED**.
-3. The **RED LED** will briefly flash to indicate a long press has been made
-4. The **RED LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
-5. The **BLUE LED** will turn on for 2 seconds to indicated bluetooth mode is active.
-6. A long press of the [**ENTER**] key can be used to determine the configuration options. [See Configuration Options](configuration.md)
-7. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
-8. Motor error states are indicated by the **GREEN LED** on the other side of the Nordic board. motor initialization errors are indicated by a slowly flashing LED, firmware mismatch errors are indicated by a fast flashing LED, and configuration errors are indicated by a steady on LED.
+2.  The **GREEN LED** will flash once briefly when the [**PLUS**] or [**MINUS**] keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the [**PLUS**] or [**MINUS**] keys key will cause the led to briefly flash **RED** multiple times to indicate the limit has been reached. 
+3.  If the motor is off, pressing the [**PLUS**] or [**MINUS**] keys will cause a **RED** LED to flash.
+4. The **RED LED** will briefly flash to indicate a long press has been made
+5. The **RED LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
+6. The **BLUE LED** will turn on for 2 seconds to indicated bluetooth mode is active.
+7. A long press of the [**ENTER**] key can be used to determine the configuration options. [See Configuration Options](configuration.md)
+8. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
+9. Motor error states are indicated by the **GREEN LED** on the other side of the Nordic board. motor initialization errors are indicated by a slowly flashing LED, firmware mismatch errors are indicated by a fast flashing LED, and configuration errors are indicated by a steady on LED.
+## LED Signalling (Configuration mode)
 
-
-## Short Press buttons
+## Short Press buttons (Normal Mode)
 ----
 * Short Press the [**POWER**] button to display the motor battery state of charge. 
-* Short Press the [**ENTER**] button to display the current assist level by flashing the GREEN LED. ie: 3 flashes indicated that the motor is in assist level 3 
+* Short Press the [**ENTER**] button to page up on a connected garmin bike computer
 * Short press the [**PLUS**] button to increase the motor assist level (ANT+ LEV control)
 * Short press the [**MINUS**] button to decrease the motor assist level (ANT+ LEV control)
   
-## Long Press Buttons
+## Long Press Buttons (Normal Mode)
 -----
 * Long Press the [**POWER**] button to turn on/off the motor. See LED Operation Signalling above for a description of operation.
 * Long Press the [**PLUS**] button to pageup on a garmin bike computer
 * Long Press the [**MINUS**] button to pagedown on a garmin bike computer
-* Long press the [**ENTER**] button to cycle through the configuration LED display.     [See Configuration Options](configuration.md)
+* Long press the [**ENTER**] button to page down on a connected gaarmin bike computer
+* to cycle through the configuration LED display.     [See Configuration Options](configuration.md)
 * Long Press both the [**ENTER**] + [**POWER**] buttons at the same time for 10 seconds or longer to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
 * Long press the [**PLUS**] + [**POWER**] buttons to start bluetooth to allow the [Configuration Options](configuration.md)  to be set. 
 * Long press the [**MINUS**] + [**POWER**] buttons to stop bluetooth to save power. 
 * Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode
 
+
+## Short Press buttons (Normal Mode)
+## Long Press buttons (Configuration Mode)
 Bluetooth will also automatically turn off after:
     * 5 minutes if you left bluetooth running
     * After you change any [Configuration Options](configuration.md) 

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -10,7 +10,7 @@ The remote has two operating modes, **NORMAL** **MODE** which is the usual mode 
 * Short press the [**PLUS**] button to increase the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
 * Short press the [**MINUS**] button to decrease the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
 * Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode.
-  
+* A very long press (more than 5 seconds) of the [**ENTER**] button will enter **CONFIGURATION MODE**   
 -----
 
 ## Button Operation (CONFIGURATION MODE)

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -17,8 +17,8 @@ The remote has two operating modes, **NORMAL** **MODE** which is the usual mode 
 * a short press of the [**ENTER**] key will cycle through the configuration LED display. A **RED LED** indicates support for ANT LEV ebikes, while a BLUE LED indicated support for Garmin bike computers. [See Configuration Options](configuration.md)
 * A Long press the [**ENTER**] button will exit **CONFIGURATION MODE** and return to **NORMAL MODE** . **CONFIGURATION MODE** will also automatically turn off if no keys are pressed for 5 minutes. 
 * Long Press the [**POWER**] button to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
-* Short press the [**PLUS**] button to enable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
-* Short press the [**MINUS**] button to disable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
+* Long press the [**PLUS**] button to enable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
+* Long press the [**MINUS**] button to disable support for either a Wireless TSDZ2 or an ANT LEV enabled ebike.
 * Short press the [**PLUS**] button to enable support for Garmin bike computers.
 * Short press the [**MINUS**] button to disable support for Garmin bike computers.
   

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -1,50 +1,40 @@
 # Remote operation
-LED Information Signals
+## LED Signalling
 ------
 1. ANT Searching/Connection
-   When the remote is searching for either an ANT+ LEV or an ANT+ Controls connection, the RED LED will slowly flash. When a connection is made, the RED LED will quickly flash and then go out.
-2. The GREEN LED will flash once briefly when the PLUS or MINUS keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the PLUS or MINUS keys key will cause the led to briefly flash multiple times to indicate the limit has been reached. If the motor is on, the color of the LED will be RED. 
-4. The RED LED will briefly flash to indicate  that a long press has been made.
-5. The RED LED will turn on for 2 seconds to indicated that the remote is entering DFU mode.
-6. The RED LED will turn on for up to 1 second when the brake lever is pressed, and turn off immediately when the brake lever is released.
-7. The Blue LED will flash slowly to indicate that bluetooth mode is active.
-8. A long press of the ENTER key can be used to determine the configuration options. [See Configuration Options for LED Behavior in this mode](configuration.md)
-9. A long press of the STANDBY key will turn the motor ON or OFF. When the motor is initializing, the LED will flash off-white. When the motor is on, the off-white led will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. 
-Battery state is indicated by flashing the GREEN LED. The number of flashes will indicate percent battery charge from 10% (1 flash) to 100% (10 flashes). For example, 5 flashes would indicate a 50% charge.
-7. A short press of the [STANDBY] key will also display the % battery state of charge if the motor is on. (see 6 above for a description of the LED display in this mode.
-8. Motor error states are indicated by the Green power LED on the other side of the Nordic board. There are three error states indicated:
-
-    1 - Motor initialization errors are indicated by a slowly flashing LED. 
-
-    2 - Firmware mismatch errors are indicated by a fast flashing LED. 
-
-    3 - Motor configuration errors are indicated by a full on Green LED.
+   When the remote is searching for either an ANT+ LEV or an ANT+ Controls connection, the **RED LED** will slowly flash. When a connection is made, the **RED LED** will quickly flash and then go out.
+2.  The **GREEN LED** will flash once briefly when the [**PLUS**] or [**MINUS**] keys are pressed to indicate the assist level is changing. if the assist level has reached either 0 or 7, pressing the [**PLUS**] or [**MINUS**] keys key will cause the led to briefly flash multiple times to indicate the limit has been reached. If the motor is on, the color of this LED will be **RED**.
+3. The **RED LED** will briefly flash to indicate a long press has been made
+4. The **RED LED** will turn on for 2 seconds to indicated that the remote is entering DFU mode.
+5. The **BLUE LED** will turn on for 2 seconds to indicated bluetooth mode is active.
+6. A long press of the [**ENTER**] key can be used to determine the configuration options. [See Configuration Options](configuration.md)
+7. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
+8. Motor error states are indicated by the **GREEN LED** on the other side of the Nordic board. motor initialization errors are indicated by a slowly flashing LED, firmware mismatch errors are indicated by a fast flashing LED, and configuration errors are indicated by a steady on LED.
 
 
-Short Press buttons
+## Short Press buttons
 ----
-* Short Press the [STANDBY] button to display the motor battery state of charge. 
-* Short Press the [ENTER] button to display the current assist level by flashing the GREEN LED. ie: 3 flashes indicated that the motor is in assist level 3 
-* Short press the [PLUS] button to increase the motor assist level (ANT+ LEV control)
-* Short press the [MINUS] button to decrease the motor assist level (ANT+ LEV control)
+* Short Press the [**POWER**] button to display the motor battery state of charge. 
+* Short Press the [**ENTER**] button to display the current assist level by flashing the GREEN LED. ie: 3 flashes indicated that the motor is in assist level 3 
+* Short press the [**PLUS**] button to increase the motor assist level (ANT+ LEV control)
+* Short press the [**MINUS**] button to decrease the motor assist level (ANT+ LEV control)
   
-Long Press Buttons
+## Long Press Buttons
 -----
-* Long Press the STANDBY button to turn on/off the motor. See LED Operation Signalling above for a description of operation.
-* Long Press the [PLUS] button to pageup on a garmin bike computer
-* Long Press the [MINUS] button to pagedown on a garmin bike computer
-* Long press the [ENTER] button to cycle through the configuration LED display.     [See Configuration Options](configuration.md)
-* Long Press both the [ENTER] + [STANDBY] buttons at the same time to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
-* Long press the [PLUS] + [STANDBY] buttons to start bluetooth to allow the [Configuration Options](configuration.md)  to be set. 
-* Long press the [MINUS] + [STANDBY] buttons to stop bluetooth to save power. 
-* Long press the [MINUS] + [PLUS] buttons to put the remote control in 'deep sleep' low power mode
+* Long Press the [**POWER**] button to turn on/off the motor. See LED Operation Signalling above for a description of operation.
+* Long Press the [**PLUS**] button to pageup on a garmin bike computer
+* Long Press the [**MINUS**] button to pagedown on a garmin bike computer
+* Long press the [**ENTER**] button to cycle through the configuration LED display.     [See Configuration Options](configuration.md)
+* Long Press both the [**ENTER**] + [**POWER**] buttons at the same time for 10 seconds or longer to initate Device Firmware Update (DFU) mode.  Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
+* Long press the [**PLUS**] + [**POWER**] buttons to start bluetooth to allow the [Configuration Options](configuration.md)  to be set. 
+* Long press the [**MINUS**] + [**POWER**] buttons to stop bluetooth to save power. 
+* Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode
 
 Bluetooth will also automatically turn off after:
     * 5 minutes if you left bluetooth running
     * After you change any [Configuration Options](configuration.md) 
       (See Configuration Options below)
-  * Planned feature: Long press the [POWER] button to turn off the TSDZ2 motor
-
+ 
 See controlling a Garmin 1030 bike computer for assist levels and page control using a simulated ANT+ LEV Ebike in this video:
 
 [![video](https://img.youtube.com/vi/s7URIMVzcwc/hqdefault.jpg)](https://www.youtube.com/watch?v=s7URIMVzcwc)
@@ -53,7 +43,6 @@ See changing the ANT+ LEV Device Number (to connect to only one specific eBike) 
 
 [![video](https://img.youtube.com/vi/_ALauuDxZuQ/hqdefault.jpg)](https://youtu.be/_ALauuDxZuQ) 
 
-nRFConnect is available on the play store here:
-(https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en_CA&gl=US)
+nRFConnect is available on the play store [here](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en_CA&gl=US)
 
 ## [back](../README.md)

--- a/EBike_wireless_remote/firmware/ant_lev/ant_lev.c
+++ b/EBike_wireless_remote/firmware/ant_lev/ant_lev.c
@@ -7,7 +7,7 @@
  */
 
 #include "sdk_common.h"
-
+#include "ant_error.h"
 #include "nrf_assert.h"
 #include "app_error.h"
 #include "ant_interface.h"
@@ -19,7 +19,7 @@
 #include "nrf_pwr_mgmt.h"
 #include "nrf_delay.h"
 #include "led_softblink.h"
-
+static u_int8_t desired_travel_mode;
 #define COMMON_DATA_INTERVAL 20 /**< Common data page is sent every 20th message. */
 
 void shutdown(void);
@@ -28,6 +28,51 @@ typedef struct
     ant_lev_page_t page_number;
     uint8_t page_payload[7];
 } ant_lev_message_layout_t;
+
+void send_page16(ant_lev_profile_t *p_profile)
+
+{
+
+    static uint8_t p_message_payload[ANT_STANDARD_DATA_PAYLOAD_SIZE] = {
+        ANT_LEV_PAGE_16,
+        0x01,
+        0x00,
+        0x0F,
+        0x00,
+        0x00,
+        0x00,
+        0x00};
+
+    ant_lev_message_layout_t *p_lev_message_payload =
+        (ant_lev_message_layout_t *)p_message_payload;
+
+    ant_lev_page_16_encode(p_lev_message_payload->page_payload,
+                           &(p_profile->page_16));
+
+    uint32_t err_code;
+    int count = 0;
+    do
+    {
+        count++;
+        if (count >> 1)
+        {
+            count++; //check to see if a resend attempt is needed
+            count--;
+        }
+        err_code = sd_ant_acknowledge_message_tx(p_profile->channel_number, sizeof(p_message_payload), p_message_payload);
+    } while (err_code == NRF_ANT_ERROR_TRANSFER_IN_PROGRESS);
+
+    //reset the on/off and brake flags
+    p_profile->page_16.current_front_gear = 0;
+    p_profile->page_16.current_rear_gear = 0;
+    if (err_code != 0)
+    {
+        // nrf_delay_ms(50);
+    }
+    (void)err_code; // ignore
+                    //  nrf_delay_ms(100);
+}
+
 /**@brief Function for initializing the ANT LEV profile instance.
  *
  * @param[in]  p_profile        Pointer to the profile instance.
@@ -35,6 +80,7 @@ typedef struct
  *
  * @retval     NRF_SUCCESS      If initialization was successful. Otherwise, an error code is returned.
  */
+
 static ret_code_t ant_lev_init(ant_lev_profile_t *p_profile,
                                ant_channel_config_t const *p_channel_config)
 {
@@ -70,9 +116,10 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
 {
     ASSERT(p_profile != NULL);
     bool long_press = m_button_long_press;
-    bool send_page = false;
+
     //open if previously closed
     sd_ant_channel_open(p_profile->channel_number);
+
     if (!long_press)
     {
         if (button == MINUS__PIN)
@@ -87,11 +134,13 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
                     bsp_board_led_off(LED_R__PIN);
                     nrf_delay_ms(100);
                 }
-                send_page = false;
+
+                desired_travel_mode = 0;
             }
             else
             {
                 p_profile->page_16.travel_mode -= 8;
+                desired_travel_mode = p_profile->page_16.travel_mode;
                 p_profile->page_16.current_front_gear = 0;
                 if (p_profile->page_16.travel_mode == 0)
                 {
@@ -104,7 +153,6 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
                         nrf_delay_ms(100);
                     }
                 }
-                send_page = true;
             }
 
             //p_profile->page_16.travel_mode=p_profile->common.travel_mode_state;
@@ -113,7 +161,8 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
         {
             if (p_profile->page_16.travel_mode == 56)
             {
-                send_page = false;
+
+                desired_travel_mode = 56;
                 //quickly flash led
                 for (int i = 0; i < 10; i++)
                 {
@@ -127,8 +176,9 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
 
             {
                 p_profile->page_16.travel_mode += 8;
+                desired_travel_mode = p_profile->page_16.travel_mode;
                 p_profile->page_16.current_front_gear = 0;
-                send_page = true;
+
                 if (p_profile->page_16.travel_mode == 56)
                 {
                     //quickly flash led if at limits
@@ -145,19 +195,14 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
         else if (button == ENTER__PIN)
         {
             // p_profile->page_16.wheel_circumference -= 10; //1818 circum
-
-            // send_page = true;
         }
         else if (button == STANDBY__PIN)
         {
             // p_profile->page_16.manufacturer_id += 1;
-
-            //send_page = true;
         }
         else if (button == BRAKE__PIN)
         {
             p_profile->page_16.current_rear_gear = 15;
-            send_page = true;
         }
     }
     else //long press actions
@@ -165,81 +210,14 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
         if (button == STANDBY__PIN)
         {
             p_profile->page_16.current_front_gear = 3;
-            send_page = true;
         }
         else if (button == BRAKE__PIN)
         {
             p_profile->page_16.current_rear_gear = 0;
-            send_page = true;
         }
-        /*
-        if (button == MINUS__PIN)
-        {
-            if (p_profile->page_16.travel_mode != 0)
-                p_profile->page_16.travel_mode -= 8;
-            //p_profile->page_16.travel_mode=p_profile->common.travel_mode_state;
-            send_page = true;
-        }
-        else if (button == PLUS__PIN)
-        {
-            if (p_profile->page_16.travel_mode != 56)
-                p_profile->page_16.travel_mode += 8;
-
-            send_page = true;
-        }
-        
-        if (button == ENTER__PIN)
-        {
-           p_profile->page_16.wheel_circumference += 10; //1818 circum
-
-            send_page = true;
-        }
-        else if (button == STANDBY__PIN)
-        {
-           p_profile->page_16.manufacturer_id -= 1;
-
-            send_page = true;
-        }
-        */
     }
-    // send_page = true;
-    if (send_page)
-    {
-        send_page = false;
-
-        static uint8_t p_message_payload[ANT_STANDARD_DATA_PAYLOAD_SIZE] = {
-            ANT_LEV_PAGE_16,
-            0x01,
-            0x00,
-            0x0F,
-            0x00,
-            0x00,
-            0x00,
-            0x00};
-
-        ant_lev_message_layout_t *p_lev_message_payload =
-            (ant_lev_message_layout_t *)p_message_payload;
-
-        ant_lev_page_16_encode(p_lev_message_payload->page_payload,
-                               &(p_profile->page_16));
-
-        uint32_t err_code;
-        err_code = sd_ant_acknowledge_message_tx(p_profile->channel_number, sizeof(p_message_payload), p_message_payload);
-        //reset the on/off and brake flags
-        p_profile->page_16.current_front_gear = 0;
-        p_profile->page_16.current_rear_gear = 0;
-        if (err_code != 0)
-        {
-            // nrf_delay_ms(50);
-        }
-        (void)err_code; // ignore
-                        //  nrf_delay_ms(100);
-    }
-
-    if (send_page)
-        return true;
-    else
-        return false;
+    send_page16(p_profile);
+    return true;
 }
 
 static void disp_message_decode(ant_lev_profile_t *p_profile, uint8_t *p_message_payload)
@@ -316,6 +294,13 @@ void ant_lev_disp_evt_handler(ant_evt_t *p_ant_evt, void *p_context)
                                                          p_message_payload);
                 APP_ERROR_CHECK(err_code);
             }
+            if (desired_travel_mode != p_profile->page_16.travel_mode)
+            {
+               //send it again it was missed with fast button presses
+                p_profile->page_16.travel_mode = desired_travel_mode;
+                send_page16(p_profile);
+            }
+
             /*           else
             {
                err_code = sd_ant_broadcast_message_tx(p_profile->channel_number,

--- a/EBike_wireless_remote/firmware/include/sdk_config.h
+++ b/EBike_wireless_remote/firmware/include/sdk_config.h
@@ -621,7 +621,12 @@
 //==========================================================
 
 // <h> nRF_Drivers 
+// <q> APP_GPIOTE_ENABLED  - app_gpiote - GPIOTE events dispatcher
+ 
 
+#ifndef APP_GPIOTE_ENABLED
+#define APP_GPIOTE_ENABLED 1
+#endif
 //==========================================================
 // <e> GPIOTE_ENABLED - nrf_drv_gpiote - GPIOTE peripheral driver - legacy layer
 //==========================================================
@@ -647,7 +652,7 @@
 // <7=> 7 
 
 #ifndef GPIOTE_CONFIG_IRQ_PRIORITY
-#define GPIOTE_CONFIG_IRQ_PRIORITY 6
+#define GPIOTE_CONFIG_IRQ_PRIORITY 2
 #endif
 
 // </e>
@@ -674,7 +679,7 @@
 // <7=> 7 
 
 #ifndef NRFX_GPIOTE_CONFIG_IRQ_PRIORITY
-#define NRFX_GPIOTE_CONFIG_IRQ_PRIORITY 6
+#define NRFX_GPIOTE_CONFIG_IRQ_PRIORITY 2
 #endif
 
 // <e> NRFX_GPIOTE_CONFIG_LOG_ENABLED - Enables logging in the module.

--- a/EBike_wireless_remote/firmware/main.c
+++ b/EBike_wireless_remote/firmware/main.c
@@ -74,6 +74,7 @@ int8_t mask_number = 0;
 //only one instance may be active at any time
 //softblink is the instance flag 1 means led busy, 0 or 2 means led ready
 uint8_t soft_blink = 0;
+bool config_press = false;
 //motor state control variables
 uint8_t motor_init_state;
 uint8_t motor_error_state;
@@ -81,12 +82,14 @@ uint8_t motor_soc_state;
 bool motor_display_soc = false;
 bool display_assist = false;
 
-#define BUTTON_DETECTION_DELAY APP_TIMER_TICKS(50)           /**< Delay from a GPIOTE event until a button is reported as pushed (in number of timer ticks). */
+#define BUTTON_DETECTION_DELAY APP_TIMER_TICKS(1)            /**< Delay from a GPIOTE event until a button is reported as pushed (in number of timer ticks). */
 #define BUTTON_PRESS_TIMEOUT APP_TIMER_TICKS(60 * 60 * 1000) // 1h to enter low power mode
 //#define BUTTON_PRESS_TIMEOUT APP_TIMER_TICKS(20 * 1000)
-#define BUTTON_LONG_PRESS_TIMEOUT APP_TIMER_TICKS(1000) // 1 seconds for long press
-#define ANT_Search_TIMEOUT APP_TIMER_TICKS(300)         // 300 ms for Ant Search check
-#define DEVICE_NAME "TSDZ2_remote"                      /**< Name of device. Will be included in the advertising data. */
+#define BUTTON_LONG_PRESS_TIMEOUT APP_TIMER_TICKS(1000)   // 1 seconds for long press
+#define BUTTON_CONFIG_PRESS_TIMEOUT APP_TIMER_TICKS(5000) // 5 seconds TO ENTER CONFIG MODE
+
+#define ANT_Search_TIMEOUT APP_TIMER_TICKS(300) // 300 ms for Ant Search check
+#define DEVICE_NAME "TSDZ2_remote"              /**< Name of device. Will be included in the advertising data. */
 
 #define APP_BLE_CONN_CFG_TAG 1 /**< A tag identifying the SoftDevice BLE configuration. */
 
@@ -171,6 +174,9 @@ static antplus_controls_profile_t m_antplus_controls;
 
 NRF_SDH_ANT_OBSERVER(m_ant_observer, ANT_LEV_ANT_OBSERVER_PRIO, ant_lev_disp_evt_handler, &m_ant_lev);
 NRF_SDH_ANT_OBSERVER(m_ant_observer_control, ANT_CONTROLS_ANT_OBSERVER_PRIO, antplus_controls_sens_evt_handler, &m_antplus_controls);
+uint8_t configuration_flag = 0;     // flag to determine configutaion mode 1 config mode/ 0 normal mode
+bool enable_configuration = false;  //used to turn on config mode
+bool disable_configuration = false; //used to turn off config mode
 
 uint8_t ebike = 1;  //ebike control as default                                                //ANT LEV ebike as a default
 uint8_t garmin = 0; //no garmin computer as a default
@@ -187,8 +193,7 @@ static uint16_t m_conn_handle = BLE_CONN_HANDLE_INVALID; /**< Handle of the curr
 //static uint8_t m_adv_handle = BLE_GAP_ADV_SET_HANDLE_NOT_SET;           /**< Advertising handle used to identify an advertising set. */
 //static uint8_t m_enc_advdata[BLE_GAP_ADV_SET_DATA_SIZE_MAX];            /**< Buffer for storing an encoded advertising set. */
 //static uint8_t m_enc_scan_response_data[BLE_GAP_ADV_SET_DATA_SIZE_MAX]; /**< Buffer for storing an encoded scan data. */
-bool m_turn_bluetooth_on = false; //needs to be a flag to manage flash write events
-bool m_turn_bluetooth_off = false;
+
 uint8_t old_ant_device_id = 0; // initially in pairing mode
 uint8_t new_ant_device_id = 0; // used to check for change of ant id
 
@@ -278,21 +283,21 @@ void disp_soc(void)
 void check_motor_init()
 {
   static bool soc_disp = true;
-  static bool key_disp = false;
-  
+  //static bool key_disp = false;
+
   //display SOC if standby key pressed and motor is on
- // if (motor_display_soc && motor_soc_state && key_disp && (motor_init_state == 1)) // display soc when STANDBY Key is pressed
-  if (motor_display_soc && motor_init_state==1)  // display soc when STANDBY Key is pressed
+  // if (motor_display_soc && motor_soc_state && key_disp && (motor_init_state == 1)) // display soc when STANDBY Key is pressed
+  if (motor_display_soc && motor_init_state == 1) // display soc when STANDBY Key is pressed
   {
     disp_soc();
     motor_display_soc = false;
   }
-  
+
   switch (motor_init_state)
   {
   case 0: //motor off
 
-    key_disp = false;
+    //key_disp = false;
 
     break;
   case 1: //motor on
@@ -305,7 +310,7 @@ void check_motor_init()
       soft_blink = led_softblink_uninit(); // turn off the soft_blink led
       nrf_delay_ms(1000);
       soc_disp = false;
-      key_disp = true;
+      // key_disp = true;
     }
     break;
   case 2: //motor initializing
@@ -490,6 +495,7 @@ static void ble_evt_handler(ble_evt_t const *p_ble_evt, void *p_context)
 //APP_TIMER_DEF(m_lev_send);
 APP_TIMER_DEF(m_timer_button_press_timeout);
 APP_TIMER_DEF(m_timer_button_long_press_timeout);
+APP_TIMER_DEF(m_timer_button_config_press_timeout);
 
 //APP_TIMER_DEF(m_antplus_controls_send);
 
@@ -669,9 +675,24 @@ static void led_timer_timeout(void *p_context)
 static void bluetooth_timer_timeout(void *p_context)
 {
   UNUSED_PARAMETER(p_context);
-  m_turn_bluetooth_off = true; // set the flag for the idle loop
+  disable_configuration = true;
 }
+static void timer_button_config_press_timeout_handler(void *p_context)
+{
+  UNUSED_PARAMETER(p_context);
 
+  led_pwm_on(B_LED, 100, 99, 1, 2000); //100 ms on
+  nrf_delay_ms(4000);
+  soft_blink = led_softblink_uninit();
+  //led_pwm_on(B_LED, 255, 254, 1, 1000); //flash the blue led to indicate long press
+  //nrf_delay_ms(50);
+  config_press = true;
+  // enter configuration mode
+  if (configuration_flag)
+    disable_configuration = true;
+  else
+    enable_configuration = true;
+}
 static void timer_button_press_timeout_handler(void *p_context)
 {
   UNUSED_PARAMETER(p_context);
@@ -692,33 +713,11 @@ static void timer_button_long_press_timeout_handler(void *p_context)
   led_pwm_on(R_LED, 100, 99 - 1, 1, 25); //flash the red led to indicate long press
   nrf_delay_ms(50);
   soft_blink = led_softblink_uninit();
-/*
+  /*
   
   //CONFIG DISPLAY
   if (nrf_gpio_pin_read(ENTER__PIN) == 0)
   {
-    nrf_delay_ms(2000);
-    if (ebike && !soft_blink)
-    {
-      led_pwm_on(R_LED, 100, 99, 1, 100); //100 ms on
-      nrf_delay_ms(1000);
-      soft_blink = led_softblink_uninit();
-    }
-
-    if (garmin && !soft_blink)
-    {
-      led_pwm_on(G_LED, 100, 99, 1, 100); //100 ms on
-      nrf_delay_ms(1000);
-      soft_blink = led_softblink_uninit();
-    }
-
-    //led 2 (blue) brake control active
-    if (brake && !soft_blink)
-    {
-      led_pwm_on(B_LED, 100, 99, 1, 100); //100 ms on
-      nrf_delay_ms(1000);
-      soft_blink = led_softblink_uninit();
-    }
   }
 */
   //pageup/pagedown
@@ -738,7 +737,7 @@ static void timer_button_long_press_timeout_handler(void *p_context)
     }
     buttons_send_pag73(&m_antplus_controls, ENTER__PIN, 1);
   }
-  
+
   // check for enter bootloader buttons
   if ((nrf_gpio_pin_read(ENTER__PIN) == 0) && (nrf_gpio_pin_read(STANDBY__PIN) == 0))
 
@@ -755,13 +754,13 @@ static void timer_button_long_press_timeout_handler(void *p_context)
 
   {
     // set flag to enable bluetooth on restart - needed because of interrupt priority
-    m_turn_bluetooth_on = true;
+    enable_configuration = true;
   }
 
   if ((nrf_gpio_pin_read(MINUS__PIN) == 0) && (nrf_gpio_pin_read(STANDBY__PIN) == 0))
   {
-    // set flag to enable bluetooth on restart - needed because of interrupt priority
-    m_turn_bluetooth_off = true;
+    // set flag to disable bluetooth on restart - needed because of interrupt priority
+    disable_configuration = true;
   }
 
   if ((nrf_gpio_pin_read(MINUS__PIN) == 0) && (nrf_gpio_pin_read(PLUS__PIN) == 0))
@@ -784,127 +783,185 @@ static void button_event_handler(uint8_t pin_no, uint8_t button_action)
 {
   button_pins_t button_pin = (button_pins_t)pin_no;
   ret_code_t err_code;
-  switch (button_action)
+  if (configuration_flag)
   {
-  case APP_BUTTON_RELEASE: //process the button actions
-
-    if (button_pin == MINUS__PIN)
+    //configuration buttons
+    switch (button_action)
     {
-      if (plus_minus_flag)
-        shutdown_flag = true; //needed because button release will wake up the board
-
-      if ((ebike) && (!m_button_long_press))
+    case APP_BUTTON_PUSH:
+      if (button_pin == ENTER__PIN)
       {
-        if (motor_init_state == 1)
+      //start the config timer
+      err_code = app_timer_start(m_timer_button_config_press_timeout, BUTTON_CONFIG_PRESS_TIMEOUT, NULL); //start the long press timer
+      APP_ERROR_CHECK(err_code);
+      }
+      break;
+    case APP_BUTTON_RELEASE: //process the button actions
+
+      if ((button_pin == ENTER__PIN) && (!config_press))
+      {
+        err_code = app_timer_stop(m_timer_button_config_press_timeout); //stop the config  timer
+        APP_ERROR_CHECK(err_code);
+        if (ebike && !soft_blink)
         {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(50);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
-          buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
+          led_pwm_on(R_LED, 100, 99, 1, 100); //100 ms on
+          nrf_delay_ms(1000);
+          soft_blink = led_softblink_uninit();
         }
-        else
+
+        if (garmin && !soft_blink)
         {
-          bsp_board_led_on(LED_R__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_R__PIN); //briefly display red led
+          led_pwm_on(G_LED, 100, 99, 1, 100); //100 ms on
+          nrf_delay_ms(1000);
+          soft_blink = led_softblink_uninit();
+        }
+        /*
+        //led 2 (blue) brake control active
+        if (brake && !soft_blink)
+        {
+          led_pwm_on(B_LED, 100, 99, 1, 100); //100 ms on
+          nrf_delay_ms(1000);
+          soft_blink = led_softblink_uninit();
+        }
+        */
+      }
+      break;
+    }
+  }
+  else
+  {
+    switch (button_action)
+    {
+    case APP_BUTTON_RELEASE: //process the button actions
+      if (button_pin == ENTER__PIN)
+      {
+        err_code = app_timer_stop(m_timer_button_config_press_timeout); //stop the config  timer
+        APP_ERROR_CHECK(err_code);
+      }
+      if (button_pin == MINUS__PIN)
+      {
+        if (plus_minus_flag)
+          shutdown_flag = true; //needed because button release will wake up the board
+
+        if ((ebike) && (!m_button_long_press))
+        {
+          if (motor_init_state == 1)
+          {
+            bsp_board_led_on(LED_G__PIN); //briefly display red led
+            nrf_delay_ms(25);
+            bsp_board_led_off(LED_G__PIN); //briefly display red led
+            buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
+          }
+          else
+          {
+            bsp_board_led_on(LED_R__PIN); //briefly display red led
+            nrf_delay_ms(5);
+            bsp_board_led_off(LED_R__PIN); //briefly display red led
+          }
         }
       }
-    }
-    else if (button_pin == BRAKE__PIN)
-    {
-      //turn off the brake led
-      soft_blink = led_softblink_uninit();
-      //set the brake flag in the rear gearing to signal that the brake has been pressed
-      m_button_long_press = true;
-      buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
-    }
-    else if (button_pin == STANDBY__PIN && (motor_init_state==1))
-    {                           //display the battery SOC
-      motor_display_soc = true; //flag needed due to interrupt priority
-      
-    }
-    else if (button_pin == PLUS__PIN)
-    {
-      if (plus_minus_flag)
-        shutdown_flag = true; //needed because button release will wake up the board
-
-      if ((ebike) && (!m_button_long_press))
+      else if (button_pin == BRAKE__PIN)
       {
-        if (motor_init_state == 1)
+        //turn off the brake led
+        soft_blink = led_softblink_uninit();
+        //set the brake flag in the rear gearing to signal that the brake has been pressed
+        m_button_long_press = true;
+        buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
+      }
+      else if (button_pin == STANDBY__PIN && (motor_init_state == 1))
+      {                           //display the battery SOC
+        motor_display_soc = true; //flag needed due to interrupt priority
+      }
+      else if (button_pin == PLUS__PIN)
+      {
+        if (plus_minus_flag)
+          shutdown_flag = true; //needed because button release will wake up the board
+
+        if ((ebike) && (!m_button_long_press))
         {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(50);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
-          buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
-        }
-        else
-        {
-          bsp_board_led_on(LED_R__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_R__PIN); //briefly display red led
+          if (motor_init_state == 1)
+          {
+            bsp_board_led_on(LED_G__PIN); //briefly display red led
+            nrf_delay_ms(25);
+            bsp_board_led_off(LED_G__PIN); //briefly display red led
+            buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
+          }
+          else
+          {
+            bsp_board_led_on(LED_R__PIN); //briefly display red led
+            nrf_delay_ms(5);
+            bsp_board_led_off(LED_R__PIN); //briefly display red led
+          }
         }
       }
-    }
-    else if ((button_pin == ENTER__PIN) && (!m_button_long_press))
-    //pageup on bike computer
-    {
-      // display_assist = true; // display the assist level - needed due to innterrupt priorities
-      if (garmin)
+      else if ((button_pin == ENTER__PIN) && (!m_button_long_press))
+      //pageup on bike computer
       {
-        if (motor_init_state == 1)
+        if (garmin)
         {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(50);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
+          if (motor_init_state == 1)
+          {
+            bsp_board_led_on(LED_G__PIN); //briefly display red led
+            nrf_delay_ms(50);
+            bsp_board_led_off(LED_G__PIN); //briefly display red led
+          }
+          else
+          {
+            bsp_board_led_on(LED_R__PIN); //briefly display red led
+            nrf_delay_ms(5);
+            bsp_board_led_off(LED_R__PIN); //briefly display red led
+          }
         }
-        else
-        {
-          bsp_board_led_on(LED_R__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_R__PIN); //briefly display red led
-        }
+        // display_assist = true; // display the assist level - needed due to innterrupt priorities
         buttons_send_pag73(&m_antplus_controls, button_pin, 0);
       }
-    }
 
-    m_button_long_press = false; //reset the long press timer
+      m_button_long_press = false; //reset the long press timer
 
-    //reset the button timers
-    err_code = app_timer_stop(m_timer_button_press_timeout); //1hr timeout for low power
-    APP_ERROR_CHECK(err_code);
-    err_code = app_timer_start(m_timer_button_press_timeout, BUTTON_PRESS_TIMEOUT, NULL);
-    APP_ERROR_CHECK(err_code);
-    err_code = app_timer_stop(m_timer_button_long_press_timeout); //stop the long press timer
-    APP_ERROR_CHECK(err_code);
+      //reset the button timers
+      err_code = app_timer_stop(m_timer_button_press_timeout); //1hr timeout for low power
+      APP_ERROR_CHECK(err_code);
+      err_code = app_timer_start(m_timer_button_press_timeout, BUTTON_PRESS_TIMEOUT, NULL);
+      APP_ERROR_CHECK(err_code);
+      err_code = app_timer_stop(m_timer_button_long_press_timeout); //stop the long press timer
+      APP_ERROR_CHECK(err_code);
 
-    break;
+      break;
 
-  case APP_BUTTON_PUSH:
-    m_button_long_press = false;                                  //button pushed
-    err_code = app_timer_stop(m_timer_button_long_press_timeout); //stop the long press timer
-    APP_ERROR_CHECK(err_code);
-    //send the brake signal on a button push for BRAKE__PIN
-    if (button_pin == BRAKE__PIN)
-    {
-      //set the brake flag in the rear gearing to signal that the brake has been pressed
-      buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
-      if (motor_init_state == 1) //motor is on
+    case APP_BUTTON_PUSH:
+      m_button_long_press = false;                                  //button pushed
+      err_code = app_timer_stop(m_timer_button_long_press_timeout); //stop the long press timer
+      APP_ERROR_CHECK(err_code);
+
+      //send the brake signal on a button push for BRAKE__PIN
+      if (button_pin == ENTER__PIN)
       {
-        led_pwm_on(G_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+        //start the config timer
+        err_code = app_timer_start(m_timer_button_config_press_timeout, BUTTON_CONFIG_PRESS_TIMEOUT, NULL); //start the long press timer
+        APP_ERROR_CHECK(err_code);
       }
+      if (button_pin == BRAKE__PIN)
+      {
+        //set the brake flag in the rear gearing to signal that the brake has been pressed
+        buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
+        if (motor_init_state == 1) //motor is on
+        {
+          led_pwm_on(G_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+        }
+        else
+        {
+          //display the red led
+          led_pwm_on(R_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+        }
+      }
+
       else
       {
-        //display the red led
-        led_pwm_on(R_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+        err_code = app_timer_start(m_timer_button_long_press_timeout, BUTTON_LONG_PRESS_TIMEOUT, NULL); //start the long press timer
+        APP_ERROR_CHECK(err_code);
       }
+      break;
     }
-
-    else
-    {
-      err_code = app_timer_start(m_timer_button_long_press_timeout, BUTTON_LONG_PRESS_TIMEOUT, NULL); //start the long press timer
-      APP_ERROR_CHECK(err_code);
-    }
-    break;
   }
 }
 
@@ -946,6 +1003,11 @@ void buttons_init(void)
                               timer_button_long_press_timeout_handler);
 
   APP_ERROR_CHECK(err_code);
+  err_code = app_timer_create(&m_timer_button_config_press_timeout,
+                              APP_TIMER_MODE_SINGLE_SHOT,
+                              timer_button_config_press_timeout_handler);
+
+  APP_ERROR_CHECK(err_code);
 
   err_code = app_timer_start(m_timer_button_press_timeout, BUTTON_PRESS_TIMEOUT, NULL);
   APP_ERROR_CHECK(err_code);
@@ -982,12 +1044,11 @@ void shutdown(void)
   sd_power_dcdc_mode_set(NRF_POWER_DCDC_DISABLE);
   sd_power_pof_enable(0);
   nrf_delay_ms(100);
-  
+
   nrf_gpio_cfg_default(LED1_G);
   nrf_gpio_cfg_default(LED2_R);
   nrf_gpio_cfg_default(LED2_G);
   nrf_gpio_cfg_default(LED2_B);
-
 
   nrf_gpio_cfg_default(BUTTON_1);
   nrf_gpio_cfg_default(19);
@@ -1461,8 +1522,8 @@ void check_interrupt_flags(void)
       old_ant_device_id = new_ant_device_id;
     }
 
-    // save changes and disable BLUETOOTH on restart
-    eeprom_write_variables(old_ant_device_id, 0, ebike, garmin, brake);
+    // save changes and keep in  configuration mode
+    eeprom_write_variables(old_ant_device_id, 1, ebike, garmin, brake);
     wait_and_reset();
   }
   // check to see if low power mode is requested
@@ -1472,17 +1533,15 @@ void check_interrupt_flags(void)
     shutdown();
   }
   // now check for bluetooth flag on plus button press
-  if (m_turn_bluetooth_on)
+  if (enable_configuration)
   {
-    m_turn_bluetooth_on = false;
     eeprom_write_variables(old_ant_device_id, 1, ebike, garmin, brake); // Enable BLUETOOTH on restart}
     wait_and_reset();
   }
 
   // finally check bluetooth timeout flag and minus button press
-  if (m_turn_bluetooth_off)
+  if (disable_configuration)
   {
-    m_turn_bluetooth_off = false;
     eeprom_write_variables(old_ant_device_id, 0, ebike, garmin, brake); // Disable BLUETOOTH on restart}
     wait_and_reset();
   }
@@ -1554,7 +1613,6 @@ void power_mgt_init(void)
 int main(void)
 {
   ret_code_t err_code;
-  uint8_t enable_bluetooth = 0;
 
   //lfclk_config()
   ram_retention_setup();
@@ -1568,10 +1626,10 @@ int main(void)
   buttons_init();
 
   //read the flash memory and setup the ANT ID and Bluetooth flag
-  eeprom_init(&old_ant_device_id, &enable_bluetooth, &ebike, &garmin, &brake);
+  eeprom_init(&old_ant_device_id, &configuration_flag, &ebike, &garmin, &brake);
   new_ant_device_id = old_ant_device_id; //no change at this time.
 
-  if (enable_bluetooth)
+  if (configuration_flag)
   {
     //signal that bluetooth is active
     led_pwm_on(B_LED, 100, 0, 5, 0); // start soft_blink led, 0 for no timer

--- a/EBike_wireless_remote/firmware/main.c
+++ b/EBike_wireless_remote/firmware/main.c
@@ -721,7 +721,7 @@ static void timer_button_long_press_timeout_handler(void *p_context)
 
     if (nrf_gpio_pin_read(STANDBY__PIN) == 0)
     {
-     
+
       //INDICATE ENTERING BOOTLOADER MODE
       //RED+BLUE MASK
       soft_blink = led_softblink_uninit();
@@ -731,11 +731,11 @@ static void timer_button_long_press_timeout_handler(void *p_context)
     }
     if (nrf_gpio_pin_read(PLUS__PIN) == 0)
     {
-      new_ant_device_id = 0x92;
+      new_ant_device_id = 0x90;
     }
     if (nrf_gpio_pin_read(MINUS__PIN) == 0)
     {
-      new_ant_device_id = 0x93;
+      new_ant_device_id = 0x91;
     }
   }
 
@@ -805,6 +805,14 @@ static void button_event_handler(uint8_t pin_no, uint8_t button_action)
         //start the config timer
         err_code = app_timer_start(m_timer_button_config_press_timeout, BUTTON_CONFIG_PRESS_TIMEOUT, NULL); //start the long press timer
         APP_ERROR_CHECK(err_code);
+      }
+      if (button_pin == PLUS__PIN)
+      {
+        new_ant_device_id = 0x92;
+      }
+      if (button_pin == MINUS__PIN)
+      {
+        new_ant_device_id = 0x93;
       }
       break;
     case APP_BUTTON_RELEASE:                                        //process the button actions

--- a/EBike_wireless_remote/firmware/main.c
+++ b/EBike_wireless_remote/firmware/main.c
@@ -279,12 +279,15 @@ void check_motor_init()
 {
   static bool soc_disp = true;
   static bool key_disp = false;
+  
   //display SOC if standby key pressed and motor is on
-  if (motor_display_soc && motor_soc_state && key_disp && (motor_init_state == 1)) // display soc when STANDBY Key is pressed
+ // if (motor_display_soc && motor_soc_state && key_disp && (motor_init_state == 1)) // display soc when STANDBY Key is pressed
+  if (motor_display_soc && motor_init_state==1)  // display soc when STANDBY Key is pressed
   {
     disp_soc();
     motor_display_soc = false;
   }
+  
   switch (motor_init_state)
   {
   case 0: //motor off
@@ -676,7 +679,9 @@ static void timer_button_long_press_timeout_handler(void *p_context)
   led_pwm_on(R_LED, 100, 99 - 1, 1, 25); //flash the red led to indicate long press
   nrf_delay_ms(50);
   soft_blink = led_softblink_uninit();
-
+/*
+  
+  //CONFIG DISPLAY
   if (nrf_gpio_pin_read(ENTER__PIN) == 0)
   {
     nrf_delay_ms(2000);
@@ -702,42 +707,25 @@ static void timer_button_long_press_timeout_handler(void *p_context)
       soft_blink = led_softblink_uninit();
     }
   }
-
+*/
   //pageup/pagedown
-  if ((nrf_gpio_pin_read(PLUS__PIN) == 0) && garmin)
+  if ((nrf_gpio_pin_read(ENTER__PIN) == 0) && garmin)
   {
     if (motor_init_state == 1)
+    {
+      bsp_board_led_on(LED_G__PIN); //briefly display red led
+      nrf_delay_ms(50);
+      bsp_board_led_off(LED_G__PIN); //briefly display red led
+    }
+    else
     {
       bsp_board_led_on(LED_R__PIN); //briefly display red led
       nrf_delay_ms(5);
       bsp_board_led_off(LED_R__PIN); //briefly display red led
-    }
-    else
-    {
-      bsp_board_led_on(LED_G__PIN); //briefly display red led
-      nrf_delay_ms(5);
-      bsp_board_led_off(LED_G__PIN); //briefly display red led
-    }
-    buttons_send_pag73(&m_antplus_controls, ENTER__PIN, 0);
-    
-  }
-  if ((nrf_gpio_pin_read(MINUS__PIN) == 0) && garmin)
-  {
-    if (motor_init_state == 1)
-    {
-      bsp_board_led_on(LED_R__PIN); //briefly display red led
-      nrf_delay_ms(5);
-      bsp_board_led_off(LED_R__PIN); //briefly display red led
-    }
-    else
-    {
-      bsp_board_led_on(LED_G__PIN); //briefly display red led
-      nrf_delay_ms(5);
-      bsp_board_led_off(LED_G__PIN); //briefly display red led
     }
     buttons_send_pag73(&m_antplus_controls, ENTER__PIN, 1);
-    
   }
+  
   // check for enter bootloader buttons
   if ((nrf_gpio_pin_read(ENTER__PIN) == 0) && (nrf_gpio_pin_read(STANDBY__PIN) == 0))
 
@@ -792,21 +780,21 @@ static void button_event_handler(uint8_t pin_no, uint8_t button_action)
       if (plus_minus_flag)
         shutdown_flag = true; //needed because button release will wake up the board
 
-      if ((ebike)&& (!m_button_long_press))
+      if ((ebike) && (!m_button_long_press))
       {
-        if (motor_init_state == 1) 
+        if (motor_init_state == 1)
+        {
+          bsp_board_led_on(LED_G__PIN); //briefly display red led
+          nrf_delay_ms(50);
+          bsp_board_led_off(LED_G__PIN); //briefly display red led
+          buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
+        }
+        else
         {
           bsp_board_led_on(LED_R__PIN); //briefly display red led
           nrf_delay_ms(5);
           bsp_board_led_off(LED_R__PIN); //briefly display red led
         }
-        else
-        {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
-        }
-        buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
       }
     }
     else if (button_pin == BRAKE__PIN)
@@ -817,53 +805,53 @@ static void button_event_handler(uint8_t pin_no, uint8_t button_action)
       m_button_long_press = true;
       buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
     }
-    else if (button_pin == STANDBY__PIN)
+    else if (button_pin == STANDBY__PIN && (motor_init_state==1))
     {                           //display the battery SOC
       motor_display_soc = true; //flag needed due to interrupt priority
+      
     }
     else if (button_pin == PLUS__PIN)
     {
       if (plus_minus_flag)
         shutdown_flag = true; //needed because button release will wake up the board
 
-      if ((ebike)&& (!m_button_long_press))
+      if ((ebike) && (!m_button_long_press))
       {
-        if (motor_init_state == 1) 
+        if (motor_init_state == 1)
+        {
+          bsp_board_led_on(LED_G__PIN); //briefly display red led
+          nrf_delay_ms(50);
+          bsp_board_led_off(LED_G__PIN); //briefly display red led
+          buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
+        }
+        else
         {
           bsp_board_led_on(LED_R__PIN); //briefly display red led
           nrf_delay_ms(5);
           bsp_board_led_off(LED_R__PIN); //briefly display red led
         }
-        else
-        {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
-        }
-        buttons_send_page16(&m_ant_lev, button_pin, m_button_long_press);
       }
     }
     else if ((button_pin == ENTER__PIN) && (!m_button_long_press))
     //pageup on bike computer
     {
-      display_assist = true; // display the assist level - needed due to innterrupt priorities
-                             /* if (garmin)
+      // display_assist = true; // display the assist level - needed due to innterrupt priorities
+      if (garmin)
       {
         if (motor_init_state == 1)
+        {
+          bsp_board_led_on(LED_G__PIN); //briefly display red led
+          nrf_delay_ms(50);
+          bsp_board_led_off(LED_G__PIN); //briefly display red led
+        }
+        else
         {
           bsp_board_led_on(LED_R__PIN); //briefly display red led
           nrf_delay_ms(5);
           bsp_board_led_off(LED_R__PIN); //briefly display red led
         }
-        else
-        {
-          bsp_board_led_on(LED_G__PIN); //briefly display red led
-          nrf_delay_ms(5);
-          bsp_board_led_off(LED_G__PIN); //briefly display red led
-        }
         buttons_send_pag73(&m_antplus_controls, button_pin, 0);
       }
-      */
     }
 
     m_button_long_press = false; //reset the long press timer
@@ -887,9 +875,17 @@ static void button_event_handler(uint8_t pin_no, uint8_t button_action)
     {
       //set the brake flag in the rear gearing to signal that the brake has been pressed
       buttons_send_page16(&m_ant_lev, BRAKE__PIN, m_button_long_press);
-      //display the red led
-      led_pwm_on(R_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+      if (motor_init_state == 1) //motor is on
+      {
+        led_pwm_on(G_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+      }
+      else
+      {
+        //display the red led
+        led_pwm_on(R_LED, 255, 254, 255, 1000); //keep on full brightness for 1 sec
+      }
     }
+
     else
     {
       err_code = app_timer_start(m_timer_button_long_press_timeout, BUTTON_LONG_PRESS_TIMEOUT, NULL); //start the long press timer


### PR DESCRIPTION
@casainho ,

This is a fairly extensive PR that incorporates the following changes:

   • As you requested, the assist command is now only sent when the motor is on

  • As you requested, the  LED is now RED when motor is off and GREEN when motor is on for assist and brake

  • I have confirmed that you can miss assist commands when you click quickly. There appear to be two reasons for this.
1. The first reason is because ANT is still processing the previous command when a new command is being sent. In this case, I now resend the command when ANT is not busy. However, the same problem happens at the motor side, and in this case, I do not get an error returned to the remote. To address  this case, I look at the motor's current assist level and if it does not agree with the desired assist level, I send an extra command to fix it.

2. The second reason is if you click EXTREMELY fast, the button interrupts do not fire for every click. This can be seen when the led doesn't light up, indicating the interrupt didn't happen. To try to fix this,  I have given the buttons the highest interrupt priority to try to help this, (from level 6 to level 2) and reduced the debounce time. However, the softdevice has an even higher priority and this can cause button clicks to be missed. The only other thing to do is to set BUTTON_HIGH_ACCURACY_ENABLED but this increases power conssumption, so is not an option.  The user simply cannot expect every button press to work if they click extremely fast. Try to avoid this when making assist changes. 

  • As you requested I have doubled the flash duration for assist change
  • I have also Removed the display of assist level to simplify remote operation
  •  Added short press ENTER key to page up on a connected garmin bike computer; Long press ENTER to page down
  • to simplify, I Removed battery SOC when turning on the motor, leave for short press of pwr button and when motor turns off.


Major new feature added  -Configuration mode-
To simplify the operation of the remote, I moved all configuration settings and display into this mode.
To enter the mode use an extra long press of enter key for 5 seconds or longer. the mode will activate bluetooth will activate and led will flash blue
Configuration options can be set by bluetooth.

**Configuration mode key functionality:**
ENTER key short press- show configuration information
Enter key long press - enter/exit configuration mode. Configuration mode will also timeout after 5 minutes of inactivity.
POWER key long press -enter DFU mode
PLUS key long press - turn on garmin bike computer ANT LEV support
MINUS key long  press - turn off garmin bike computer ANT LEV support
Removed brake configuration option as it is not needed.

I also updated the docs

