### PR TITLE
walk mode and light mode activated

### DIFF
--- a/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
@@ -52,6 +52,6 @@ void ant_lev_page_16_encode(uint8_t *p_page_buffer,
     p_outcoming_data->travel_mode = p_page_data->travel_mode;
     p_outcoming_data->manufacturer_id_lsb = ((uint8_t)p_page_data->manufacturer_id) & 0xFF;
     p_outcoming_data->manufacturer_id_msb = ((uint8_t)(p_page_data->manufacturer_id) >> 8);
-    p_outcoming_data->display_command_lsb = ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6;
+     p_outcoming_data->display_command_lsb = (((uint8_t)p_page_data->light << 3)| ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6);
     p_outcoming_data->display_command_msb = ((uint8_t)(p_page_data->current_rear_gear & 0x0C)) >> 2;
 }

--- a/EBike_wireless_TSDZ2/firmware/main.c
+++ b/EBike_wireless_TSDZ2/firmware/main.c
@@ -430,6 +430,23 @@ void ant_lev_evt_handler_post(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
 
   case ANT_LEV_PAGE_16_UPDATED:
 
+    if (p_profile->page_16.light)
+    {
+      //light mode activated
+      nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
+    }
+    else
+    {
+      // light mode  deactivated
+
+      nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
+    }
+
+    if (p_profile->page_16.current_rear_gear == 14)
+    {
+      // walk mode is activated
+      
+    }
     if (p_profile->page_16.current_rear_gear == 15)
     {
       // enable brakes: be as fast as possible
@@ -437,6 +454,8 @@ void ant_lev_evt_handler_post(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
     }
     if (p_profile->page_16.current_rear_gear == 0)
     {
+      //this state sshould clear both brakes and walk mode
+      // disable walk mode
       // disable brakes: be as fast as possible
       nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
     }

--- a/EBike_wireless_TSDZ2/firmware/main.c
+++ b/EBike_wireless_TSDZ2/firmware/main.c
@@ -433,13 +433,12 @@ void ant_lev_evt_handler_post(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
     if (p_profile->page_16.light)
     {
       //light mode activated
-      nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
+      
     }
     else
     {
       // light mode  deactivated
 
-      nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
     }
 
     if (p_profile->page_16.current_rear_gear == 14)

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -10,13 +10,14 @@ In either mode, if the key is pressed while inactive the **RED LED** will briefl
 
 ----
 
-* Short Press the [**POWER**] button to display the motor battery state of charge. (Motor On **ONLY**.)
-  
+* Short Press the [**POWER**] button to display the motor battery state of charge. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge). (Motor On **ONLY**.)  
 * Long Press the [**POWER**] button to turn on/off the motor. See **LED Signalling** below for a description of operation.
-* Short Press the [**ENTER**] button to **PAGE UP** on a connected garmin bike computer. 
+* Short Press the [**ENTER**] button to **PAGE UP** on a connected garmin bike computer. (Works **ONLY** if garmin control is activated)
 * Long Press the [**ENTER**] button to **PAGE DOWN** on a connected garmin bike computer. (Works **ONLY** if garmin control is activated)
 * Short press the [**PLUS**] button to increase the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
+* Long press the [**PLUS**] button to toggle the lights on/off (Light support is a planned feature, not yet implemented)
 * Short press the [**MINUS**] button to decrease the motor assist level (Wireless TSDZ2 and supported **ANT+ LEV** enabled e-bikes)
+* Long press and hold the [**MINUS**] button to start the motor walk assist. Releasing the [**MINUS**] button stops walk assist (Wlak assist is a planned feature, not yet implemented)
 * Long press the [**MINUS**] + [**PLUS**] buttons to put the remote control in 'deep sleep' low power mode.
 * A very long press (more than 5 seconds) of the [**ENTER**] button will enter **CONFIGURATION MODE**
   
@@ -46,7 +47,8 @@ In either mode, if the key is pressed while inactive the **RED LED** will briefl
 3. If the motor is off, pressing the [**PLUS**] or [**MINUS**] keys will cause a **RED** LED to flash. The assist level will NOT change with the motor off. 
 4. The **RED LED** will briefly flash to indicate a long press has been made
 5. A very long press (> 5 seconds) of the [**ENTER**] key will flash the BLUE LED for 2 seconds when entering the configuration mode.
-6. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash, followed 2 seconds later by a display of the motor battery state. If the motor is turning off, the battery state will also be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
+6. A long press of the [**POWER**] key will turn the motor ON or OFF. When the motor is initializing, the leds will flash [**OFF-WHITE**]. When the motor is on, the **OFF-WHITE LED** will rapidly flash. If the motor is turning off, the battery state will be displayed. Battery state is indicated by flashing the **GREEN LED**. The number of flashes will indicate battery charge state from from 1 flash (10% charge) to 10 flashes (100% charge).
+7. When walk mode is active the **BLUE LED** will flash slowly.
 
 ----
 

--- a/EBike_wireless_remote/firmware/ant_lev/ant_lev.c
+++ b/EBike_wireless_remote/firmware/ant_lev/ant_lev.c
@@ -198,12 +198,28 @@ bool buttons_send_page16(ant_lev_profile_t *p_profile, button_pins_t button, boo
         {
             p_profile->page_16.current_rear_gear = 15;
         }
+        else if (button == 55) //walk mode
+        {
+            p_profile->page_16.current_rear_gear = 14;
+        }
+        else if (button == 54) //light mode
+        {
+            if (p_profile->page_16.light == true)
+                p_profile->page_16.light = false;
+            else
+                p_profile->page_16.light = true;
+        }
     }
     else //long press actions
     {
+
         if (button == STANDBY__PIN)
         {
             p_profile->page_16.current_front_gear = 3;
+        }
+        else if (button == 55) //clear walk_mode command
+        {
+            p_profile->page_16.current_rear_gear = 0;
         }
         else if (button == BRAKE__PIN)
         {

--- a/EBike_wireless_remote/firmware/ant_lev/pages/ant_lev_page_16.c
+++ b/EBike_wireless_remote/firmware/ant_lev/pages/ant_lev_page_16.c
@@ -50,6 +50,6 @@ void ant_lev_page_16_encode(uint8_t *p_page_buffer,
     p_outcoming_data->travel_mode = p_page_data->travel_mode;
     p_outcoming_data->manufacturer_id_lsb = ((uint8_t)p_page_data->manufacturer_id) & 0xFF;
     p_outcoming_data->manufacturer_id_msb = ((uint8_t)(p_page_data->manufacturer_id) >> 8);
-    p_outcoming_data->display_command_lsb = ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6;
+    p_outcoming_data->display_command_lsb = (((uint8_t)p_page_data->light << 3)| ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6);
     p_outcoming_data->display_command_msb = ((uint8_t)(p_page_data->current_rear_gear & 0x0C)) >> 2;
 }


### PR DESCRIPTION
@casainho ,
This PR implements walk mode for the remote 
a long press (and hold) on MINUS will start walk mode and a blue led will start slowly flashing
when the MINUS key is release walk mode stops.

A long press of the PLUS key will toggle lights ON/OFF.

Remote docs updates also 

Of course, this needs the new code by @beemac.
Both walk and light modes can be hooked into here:

``
`case ANT_LEV_PAGE_16_UPDATED:

    if (p_profile->page_16.light)
    {
      //light mode activated
        }
    else
    {
      // light mode  deactivated
        }

    if (p_profile->page_16.current_rear_gear == 14)
    {
      // walk mode is activated
    }
    if (p_profile->page_16.current_rear_gear == 15)
    {
      // enable brakes: be as fast as possible
      nrf_gpio_port_out_clear(NRF_P0, 1UL << BRAKE__PIN);
    }
    if (p_profile->page_16.current_rear_gear == 0)
    {
      //this state ssould clear both brakes and walk mode
      // disable walk mode
      // disable brakes: be as fast as possible
      nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
    }
`
``