### PR TITLE
New connectIQ data field

### DIFF
--- a/EBike_wireless_TSDZ2/firmware/ant_lev/ant_lev.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/ant_lev.c
@@ -15,36 +15,36 @@
 #include "ant_lev.h"
 #include "app_error.h"
 
-#define COMMON_DATA_INTERVAL 20          /**< Common data page is sent every 20th message. */
+#define COMMON_DATA_INTERVAL 20 /**< Common data page is sent every 20th message. */
 
 typedef struct
 {
-    ant_lev_page_t  page_number;
-    uint8_t         page_payload[7];
+    ant_lev_page_t page_number;
+    uint8_t page_payload[7];
 } ant_lev_message_layout_t;
 
-static ret_code_t ant_lev_init(ant_lev_profile_t          * p_profile,
-                               ant_channel_config_t const * p_channel_config)
+static ret_code_t ant_lev_init(ant_lev_profile_t *p_profile,
+                               ant_channel_config_t const *p_channel_config)
 {
     p_profile->channel_number = p_channel_config->channel_number;
 
-    p_profile->page_1  = DEFAULT_ANT_LEV_PAGE1();
-    p_profile->page_2  = DEFAULT_ANT_LEV_PAGE2();
-    p_profile->page_3  = DEFAULT_ANT_LEV_PAGE3();
-    p_profile->page_4  = DEFAULT_ANT_LEV_PAGE4();
-    p_profile->page_5  = DEFAULT_ANT_LEV_PAGE5();
+    p_profile->page_1 = DEFAULT_ANT_LEV_PAGE1();
+    p_profile->page_2 = DEFAULT_ANT_LEV_PAGE2();
+    p_profile->page_3 = DEFAULT_ANT_LEV_PAGE3();
+    p_profile->page_4 = DEFAULT_ANT_LEV_PAGE4();
+    p_profile->page_5 = DEFAULT_ANT_LEV_PAGE5();
     p_profile->page_16 = DEFAULT_ANT_LEV_PAGE16();
     p_profile->page_34 = DEFAULT_ANT_LEV_PAGE34();
-    p_profile->common  = DEFAULT_ANT_LEV_COMMON_DATA();
+    p_profile->common = DEFAULT_ANT_LEV_COMMON_DATA();
     p_profile->page_80 = DEFAULT_ANT_COMMON_page80();
     p_profile->page_81 = DEFAULT_ANT_COMMON_page81();
 
     return ant_channel_init(p_channel_config);
 }
 
-ret_code_t ant_lev_sens_init(ant_lev_profile_t           * p_profile,
-                             ant_channel_config_t const  * p_channel_config,
-                             ant_lev_sens_config_t const * p_sens_config)
+ret_code_t ant_lev_sens_init(ant_lev_profile_t *p_profile,
+                             ant_channel_config_t const *p_channel_config,
+                             ant_lev_sens_config_t const *p_sens_config)
 {
     ASSERT(p_profile != NULL);
     ASSERT(p_channel_config != NULL);
@@ -53,23 +53,23 @@ ret_code_t ant_lev_sens_init(ant_lev_profile_t           * p_profile,
     ASSERT(p_sens_config->evt_handler_pre != NULL);
     ASSERT(p_sens_config->evt_handler_post != NULL);
 
-    p_profile->evt_handler_pre    = p_sens_config->evt_handler_pre;
-    p_profile->evt_handler_post   = p_sens_config->evt_handler_post;
+    p_profile->evt_handler_pre = p_sens_config->evt_handler_pre;
+    p_profile->evt_handler_post = p_sens_config->evt_handler_post;
     p_profile->_cb.p_sens_cb = p_sens_config->p_cb;
     ant_request_controller_init(&(p_profile->_cb.p_sens_cb->req_controller));
 
-    p_profile->_cb.p_sens_cb->block_cnt    = 0;
-    p_profile->_cb.p_sens_cb->pag_2_34    = 0;
-    p_profile->_cb.p_sens_cb->pag_4_5    = 0;
+    p_profile->_cb.p_sens_cb->block_cnt = 0;
+    p_profile->_cb.p_sens_cb->pag_2_34 = 1;
+    p_profile->_cb.p_sens_cb->pag_4_5 = 1;
     p_profile->_cb.p_sens_cb->message_counter = 0;
     p_profile->_cb.p_sens_cb->common_page_number = ANT_LEV_PAGE_80;
 
     return ant_lev_init(p_profile, p_channel_config);
 }
 
-static ant_lev_page_t next_page_number_get(ant_lev_profile_t * p_profile)
+static ant_lev_page_t next_page_number_get(ant_lev_profile_t *p_profile)
 {
-    ant_lev_sens_cb_t * p_lev_cb = p_profile->_cb.p_sens_cb;
+    ant_lev_sens_cb_t *p_lev_cb = p_profile->_cb.p_sens_cb;
     ant_lev_page_t page_number;
 
     if (ant_request_controller_pending_get(&(p_lev_cb->req_controller), (uint8_t *)&page_number))
@@ -78,10 +78,11 @@ static ant_lev_page_t next_page_number_get(ant_lev_profile_t * p_profile)
     }
     else if (p_lev_cb->message_counter == (COMMON_DATA_INTERVAL)) // send either 80 or 81 common data page
     {
-        page_number  = p_lev_cb->common_page_number;
+        page_number = p_lev_cb->common_page_number;
         // next time will send the other common page: either 80 or 81
         p_lev_cb->common_page_number = (p_lev_cb->common_page_number == ANT_LEV_PAGE_80)
-                                     ? ANT_LEV_PAGE_81 : ANT_LEV_PAGE_80;
+                                           ? ANT_LEV_PAGE_81
+                                           : ANT_LEV_PAGE_80;
         p_lev_cb->message_counter = 0;
         p_lev_cb->block_cnt = 1;
     }
@@ -89,30 +90,34 @@ static ant_lev_page_t next_page_number_get(ant_lev_profile_t * p_profile)
     {
         switch (p_lev_cb->block_cnt)
         {
-            case 1:
-                page_number = ANT_LEV_PAGE_1;
-                p_lev_cb->block_cnt = 2;
-                break;
 
-            case 2:
-                page_number = ANT_LEV_PAGE_2;
-                p_lev_cb->block_cnt = 3;
-                break;
+        case 1:
+            page_number = ANT_LEV_PAGE_1;
+            p_lev_cb->block_cnt = 2;
+            break;
 
-            case 3:
-                page_number = ANT_LEV_PAGE_3;
-                p_lev_cb->block_cnt = 5;
-                break;
+        case 2:
+            page_number = ANT_LEV_PAGE_2;
+            p_lev_cb->block_cnt = 3;
+            break;
 
-            case 5:
+        case 3:
+            page_number = ANT_LEV_PAGE_3;
+            p_lev_cb->block_cnt = 5;
+            break;
+
+        case 5:
+            if (p_lev_cb->message_counter >= 10)
+                page_number = ANT_LEV_PAGE_4; //every 10 messages (half the cycle)
+            else
                 page_number = ANT_LEV_PAGE_5;
-                p_lev_cb->block_cnt = 1;
-                break;
+            p_lev_cb->block_cnt = 1;
+            break;
 
-            default:
-                page_number = ANT_LEV_PAGE_1;
-                p_lev_cb->block_cnt = 2;
-                break;
+        default:
+            page_number = ANT_LEV_PAGE_1;
+            p_lev_cb->block_cnt = 2;
+            break;
         }
 
         p_lev_cb->message_counter++;
@@ -121,9 +126,9 @@ static ant_lev_page_t next_page_number_get(ant_lev_profile_t * p_profile)
     return page_number;
 }
 
-static void sens_message_encode(ant_lev_profile_t * p_profile, uint8_t * p_message_payload)
+static void sens_message_encode(ant_lev_profile_t *p_profile, uint8_t *p_message_payload)
 {
-    ant_lev_message_layout_t * p_lev_message_payload =
+    ant_lev_message_layout_t *p_lev_message_payload =
         (ant_lev_message_layout_t *)p_message_payload;
 
     p_lev_message_payload->page_number = next_page_number_get(p_profile);
@@ -132,125 +137,133 @@ static void sens_message_encode(ant_lev_profile_t * p_profile, uint8_t * p_messa
 
     switch (p_lev_message_payload->page_number)
     {
-        case ANT_LEV_PAGE_1:
-            ant_lev_page_1_encode(p_lev_message_payload->page_payload, &(p_profile->page_1),
-                                  &(p_profile->common));
-            break;
+    case ANT_LEV_PAGE_1:
+        ant_lev_page_1_encode(p_lev_message_payload->page_payload, &(p_profile->page_1),
+                              &(p_profile->common));
+        break;
 
-        case ANT_LEV_PAGE_2:
-            ant_lev_page_2_encode(p_lev_message_payload->page_payload, &(p_profile->page_2),
-                        &(p_profile->common));
-            break;
+    case ANT_LEV_PAGE_2:
+        ant_lev_page_2_encode(p_lev_message_payload->page_payload, &(p_profile->page_2),
+                              &(p_profile->common));
+        break;
 
-        case ANT_LEV_PAGE_3:
-            ant_lev_page_3_encode(p_lev_message_payload->page_payload, &(p_profile->page_3),
-                        &(p_profile->common));
-            break;
+    case ANT_LEV_PAGE_3:
+        ant_lev_page_3_encode(p_lev_message_payload->page_payload, &(p_profile->page_3),
+                              &(p_profile->common));
+        break;
 
-        case ANT_LEV_PAGE_4:
-            ant_lev_page_4_encode(p_lev_message_payload->page_payload, &(p_profile->page_4));
-            break;
+    case ANT_LEV_PAGE_4:
+        ant_lev_page_4_encode(p_lev_message_payload->page_payload, &(p_profile->page_4));
+        break;
 
-        case ANT_LEV_PAGE_5:
-            ant_lev_page_5_encode(p_lev_message_payload->page_payload, &(p_profile->page_5));
-            break;
+    case ANT_LEV_PAGE_5:
+        ant_lev_page_5_encode(p_lev_message_payload->page_payload, &(p_profile->page_5));
+        break;
 
-        case ANT_LEV_PAGE_34:
-            ant_lev_page_34_encode(p_lev_message_payload->page_payload, &(p_profile->page_34),
-                        &(p_profile->common));
-            break;            
+    case ANT_LEV_PAGE_34:
+        ant_lev_page_34_encode(p_lev_message_payload->page_payload, &(p_profile->page_34),
+                               &(p_profile->common));
+        break;
 
-        case ANT_LEV_PAGE_80:
-            antplus_common_page_80_encode(p_lev_message_payload->page_payload, &(p_profile->page_80));
-            break;
+    case ANT_LEV_PAGE_80:
+        antplus_common_page_80_encode(p_lev_message_payload->page_payload, &(p_profile->page_80));
+        break;
 
-        case ANT_LEV_PAGE_81:
-            antplus_common_page_81_encode(p_lev_message_payload->page_payload, &(p_profile->page_81));
-            break;
+    case ANT_LEV_PAGE_81:
+        antplus_common_page_81_encode(p_lev_message_payload->page_payload, &(p_profile->page_81));
+        break;
 
-        default:
-            return;
+    default:
+        return;
     }
 }
 
-static void disp_message_decode(ant_lev_profile_t * p_profile, uint8_t * p_message_payload)
+static void disp_message_decode(ant_lev_profile_t *p_profile, uint8_t *p_message_payload)
 {
-    const ant_lev_message_layout_t * p_lev_message_payload =
+    const ant_lev_message_layout_t *p_lev_message_payload =
         (ant_lev_message_layout_t *)p_message_payload;
 
     switch (p_lev_message_payload->page_number)
     {
-        case ANT_LEV_PAGE_16:
-            ant_lev_page_16_decode(p_lev_message_payload->page_payload,
-                                  &(p_profile->page_16));
-            break;
+    case ANT_LEV_PAGE_16:
+        ant_lev_page_16_decode(p_lev_message_payload->page_payload,
+                               &(p_profile->page_16));
+        if (p_profile->page_16.light)
+        {
+            p_profile->page_16.light = true;
+            p_profile->page_16.light_beam = true;
+        }
+        else
+        {
+            p_profile->page_16.light = false;
+            p_profile->page_16.light_beam = false;
+        }
+        break;
 
-        default:
-            return;
+    default:
+        return;
     }
 
     p_profile->evt_handler_post(p_profile, (ant_lev_evt_t)p_lev_message_payload->page_number);
 }
 
-void ant_lev_sens_evt_handler(ant_evt_t * p_ant_evt, void * p_context)
+void ant_lev_sens_evt_handler(ant_evt_t *p_ant_evt, void *p_context)
 {
     ASSERT(p_context != NULL);
     ASSERT(p_ant_evt != NULL);
-    ant_lev_profile_t * p_profile = (ant_lev_profile_t *)p_context;
+    ant_lev_profile_t *p_profile = (ant_lev_profile_t *)p_context;
 
     if (p_ant_evt->channel == p_profile->channel_number)
     {
         uint32_t err_code;
         uint8_t p_message_payload[ANT_STANDARD_DATA_PAYLOAD_SIZE];
-        ant_lev_sens_cb_t * p_lev_cb = p_profile->_cb.p_sens_cb;
+        ant_lev_sens_cb_t *p_lev_cb = p_profile->_cb.p_sens_cb;
         ant_request_controller_sens_evt_handler(&(p_lev_cb->req_controller), p_ant_evt);
 
         switch (p_ant_evt->event)
         {
-            case EVENT_TX:
-            case EVENT_TRANSFER_TX_FAILED:
-            case EVENT_TRANSFER_TX_COMPLETED:
-                sens_message_encode(p_profile, p_message_payload);
-                if (ant_request_controller_ack_needed(&(p_lev_cb->req_controller)))
-                {
-                    err_code = sd_ant_acknowledge_message_tx(p_profile->channel_number,
-                                                             sizeof(p_message_payload),
-                                                             p_message_payload);
-                }
-                else
-                {
-                    err_code = sd_ant_broadcast_message_tx(p_profile->channel_number,
-                                                           sizeof(p_message_payload),
-                                                           p_message_payload);
-                }
-                APP_ERROR_CHECK(err_code);
-                break;
+        case EVENT_TX:
+        case EVENT_TRANSFER_TX_FAILED:
+        case EVENT_TRANSFER_TX_COMPLETED:
+            sens_message_encode(p_profile, p_message_payload);
+            if (ant_request_controller_ack_needed(&(p_lev_cb->req_controller)))
+            {
+                err_code = sd_ant_acknowledge_message_tx(p_profile->channel_number,
+                                                         sizeof(p_message_payload),
+                                                         p_message_payload);
+            }
+            else
+            {
+                err_code = sd_ant_broadcast_message_tx(p_profile->channel_number,
+                                                       sizeof(p_message_payload),
+                                                       p_message_payload);
+            }
+            APP_ERROR_CHECK(err_code);
+            break;
 
-            case EVENT_RX:
-                if (p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_BROADCAST_DATA_ID
-                 || p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_ACKNOWLEDGED_DATA_ID
-                 || p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_BURST_DATA_ID)
-                {
-                    disp_message_decode(p_profile, p_ant_evt->message.ANT_MESSAGE_aucPayload);
-                }
-                break;
+        case EVENT_RX:
+            if (p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_BROADCAST_DATA_ID || p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_ACKNOWLEDGED_DATA_ID || p_ant_evt->message.ANT_MESSAGE_ucMesgID == MESG_BURST_DATA_ID)
+            {
+                disp_message_decode(p_profile, p_ant_evt->message.ANT_MESSAGE_aucPayload);
+            }
+            break;
 
-            case EVENT_CHANNEL_CLOSED:
-                break;
-                
-            default:
-                break;
+        case EVENT_CHANNEL_CLOSED:
+            break;
+
+        default:
+            break;
         }
     }
 }
 
-ret_code_t ant_lev_sens_open(ant_lev_profile_t * p_profile)
+ret_code_t ant_lev_sens_open(ant_lev_profile_t *p_profile)
 {
     ASSERT(p_profile != NULL);
 
     // Fill tx buffer for the first frame
     uint32_t err_code;
-    uint8_t  p_message_payload[ANT_STANDARD_DATA_PAYLOAD_SIZE];
+    uint8_t p_message_payload[ANT_STANDARD_DATA_PAYLOAD_SIZE];
 
     sens_message_encode(p_profile, p_message_payload);
     err_code =

--- a/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
@@ -52,6 +52,6 @@ void ant_lev_page_16_encode(uint8_t *p_page_buffer,
     p_outcoming_data->travel_mode = p_page_data->travel_mode;
     p_outcoming_data->manufacturer_id_lsb = ((uint8_t)p_page_data->manufacturer_id) & 0xFF;
     p_outcoming_data->manufacturer_id_msb = ((uint8_t)(p_page_data->manufacturer_id) >> 8);
-    p_outcoming_data->display_command_lsb = ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6;
+     p_outcoming_data->display_command_lsb = (((uint8_t)p_page_data->light << 3)| ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6);
     p_outcoming_data->display_command_msb = ((uint8_t)(p_page_data->current_rear_gear & 0x0C)) >> 2;
 }

--- a/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_16.c
@@ -40,8 +40,9 @@ void ant_lev_page_16_decode(const uint8_t *p_page_buffer,
     
     p_page_data->current_rear_gear = ((p_incoming_data->display_command_lsb & 0xC0) >> 6) | (((p_incoming_data->display_command_msb) & 0x03) << 2);
     p_page_data->current_front_gear = (p_incoming_data->display_command_lsb & 0x30) >> 4;
+        p_page_data->light = (p_incoming_data->display_command_lsb & 0x08) ? true : false;
     p_page_data->light_beam = (p_incoming_data->display_command_lsb & 0x04) ? true : false;
-    p_page_data->light = (p_incoming_data->display_command_lsb & 0x08) ? true : false;
+
 }
 void ant_lev_page_16_encode(uint8_t *p_page_buffer,
                             ant_lev_page_16_data_t const *p_page_data)
@@ -52,6 +53,6 @@ void ant_lev_page_16_encode(uint8_t *p_page_buffer,
     p_outcoming_data->travel_mode = p_page_data->travel_mode;
     p_outcoming_data->manufacturer_id_lsb = ((uint8_t)p_page_data->manufacturer_id) & 0xFF;
     p_outcoming_data->manufacturer_id_msb = ((uint8_t)(p_page_data->manufacturer_id) >> 8);
-     p_outcoming_data->display_command_lsb = (((uint8_t)p_page_data->light << 3)| ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6);
+    p_outcoming_data->display_command_lsb = (((uint8_t)p_page_data->light << 3)| ((uint8_t)p_page_data->current_front_gear << 4) | ((uint8_t)p_page_data->current_rear_gear & 0x03) << 6);
     p_outcoming_data->display_command_msb = ((uint8_t)(p_page_data->current_rear_gear & 0x0C)) >> 2;
 }

--- a/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_2.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_2.c
@@ -28,8 +28,8 @@ void ant_lev_page_2_encode(uint8_t * p_page_buffer,
     ant_lev_page_2_data_layout_t * p_outcoming_data = (ant_lev_page_2_data_layout_t *)p_page_buffer;
 
     p_outcoming_data->odometer_lsb = ((uint8_t) p_common_data->odometer) & 0xff;
-    p_outcoming_data->odometer = ((uint8_t) (p_common_data->odometer >> 8)) & 0x0f;
-    p_outcoming_data->odometer_msb = ((uint8_t) (p_common_data->odometer >> 16)) & 0x0f;
+    p_outcoming_data->odometer = ((uint8_t) (p_common_data->odometer >> 8)) & 0xff;
+    p_outcoming_data->odometer_msb = ((uint8_t) (p_common_data->odometer >> 16)) & 0xff;
 
     p_outcoming_data->remaining_range_lsb = ((uint8_t) p_page_data->remaining_range) & 0xff;
     p_outcoming_data->remaining_range_msn = ((uint8_t) (p_page_data->remaining_range >> 8)) & 0x0f;

--- a/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_4.c
+++ b/EBike_wireless_TSDZ2/firmware/ant_lev/pages/ant_lev_page_4.c
@@ -20,16 +20,16 @@ typedef struct
     uint8_t distance_on_current_charge_msb;
 } ant_lev_page_4_data_layout_t;
 
-void ant_lev_page_4_encode(uint8_t                    * p_page_buffer,
-                           ant_lev_page_4_data_t const * p_page_data)
+void ant_lev_page_4_encode(uint8_t *p_page_buffer,
+                           ant_lev_page_4_data_t const *p_page_data)
 {
-    ant_lev_page_4_data_layout_t * p_outcoming_data = (ant_lev_page_4_data_layout_t *)p_page_buffer;
+    ant_lev_page_4_data_layout_t *p_outcoming_data = (ant_lev_page_4_data_layout_t *)p_page_buffer;
 
-    p_outcoming_data->charging_cycle_count_lsb = ((uint8_t) p_page_data->charging_cycle_count) & 0xff;
-    p_outcoming_data->charging_cycle_count__fuel_consumption = ((uint8_t) (p_page_data->charging_cycle_count >> 8)) & 0x0f;
-    p_outcoming_data->fuel_consumption_lsb = ((uint8_t) p_page_data->fuel_consumption) & 0xff;
-    p_outcoming_data->charging_cycle_count__fuel_consumption |= ((uint8_t) (p_page_data->fuel_consumption >> 12)) & 0x0f;
+    p_outcoming_data->charging_cycle_count_lsb = ((uint8_t)p_page_data->charging_cycle_count) & 0xff;
+    p_outcoming_data->charging_cycle_count__fuel_consumption = ((uint8_t)(p_page_data->charging_cycle_count >> 8)) & 0x0f;
+    p_outcoming_data->fuel_consumption_lsb = ((uint8_t)p_page_data->fuel_consumption) & 0xff;
+    p_outcoming_data->charging_cycle_count__fuel_consumption |= (((uint8_t)(p_page_data->fuel_consumption >> 8)) & 0x0f) << 4;
     p_outcoming_data->battery_voltage = p_page_data->battery_voltage;
-    p_outcoming_data->distance_on_current_charge_lsb = ((uint8_t) p_page_data->distance_on_current_charge) & 0xff;
-    p_outcoming_data->distance_on_current_charge_msb = ((uint8_t) (p_page_data->distance_on_current_charge >> 8)) & 0x0f;
+    p_outcoming_data->distance_on_current_charge_lsb = ((uint8_t)p_page_data->distance_on_current_charge) & 0xff;
+    p_outcoming_data->distance_on_current_charge_msb = ((uint8_t)(p_page_data->distance_on_current_charge >> 8)) & 0xff;
 }

--- a/EBike_wireless_remote/firmware/main.c
+++ b/EBike_wireless_remote/firmware/main.c
@@ -557,6 +557,7 @@ void ant_lev_evt_handler(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
 
   case ANT_LEV_PAGE_34_UPDATED:
 
+
     break;
 
   case ANT_LEV_PAGE_16_UPDATED:


### PR DESCRIPTION
@casainho , this PR implements a new ConnectIQ data field that leverages all the ANT LEV capability to support the TSDZ2 wireless design.
I will discuss in more detail on the forum page, but basically this field adds all the missing ANT LEV data that the edge bike computers do not currently support like voltage, lights, distance remaining, watt hours, etc
however, I had to add dummy variable for these in main.c as below, as the ui8 and ui16 variables are currently zero.
Could you please add real values for these ASAP?
(see the relevant code below)
see the picture of the garmin bike computer.
I think this adds real value for the users.
Later we can write another connectIQ app for the rest of the info and maybe include graphical info!
Here is what the data field  looks like on the garmin:
![IMG_20210205_085944](https://user-images.githubusercontent.com/28536098/107045467-8a1de300-6793-11eb-8b0a-39adcc0805f2.jpg)
 
`//set variables for ANT transmission in order of connectIQ fields
  // 1. lev speed
  p_profile->common.lev_speed = ui_vars.ui16_wheel_speed_x10 / 10;

  //2.  assist level
  p_profile->common.travel_mode_state |= (mp_ui_vars->ui8_assist_level << 3) & 0x38;

  // 3. lights
  //set by the remote control page 16 command
  p_profile->common.system_state = p_profile->common.system_state && 0xf7; //lights off

  p_profile->common.system_state |= (mp_ui_vars->ui8_lights << 3);

  //4. state of charge
  p_profile->page_3.battery_soc = ui8_g_battery_soc;

  // 5. battery voltage
  //p_profile->page_4.battery_voltage = (ui_vars.ui16_battery_voltage_filtered_x10)/2.5;
  //battery voltage for ANT_LEV is 0.25V/bit
  p_profile->page_4.battery_voltage = 55 / 0.25;

  //6. odometer
  //3 bytes -0.01km/bit max value 167772.15km
  //p_profile->common.odometer = ui_vars.ui32_odometer_x10 / 100;
  p_profile->common.odometer = 167772; //1677.72 km

  //7. remaining range
  //1 km/bit, max value 4095km
  //p_profile->page_2.remaining_range = ui_vars.battery_energy_km_value_x100 / 100;
  p_profile->page_2.remaining_range = 4095; //km

  //8. motor temperature
  //one byte, bits 4-6
  //000 unknown
  //001  cold
  //010 cold/warm
  //011 warm
  //100 warm/hot
  //101 hot

  // p_profile->page_1.temperature_state = ui_vars.ui8_motor_temperature;
  p_profile->page_1.temperature_state = 32; //warm

  //9. fuel consumption
  //max value 0.1 wh/km per bit, max value=409.5 Wh/km
  // p_profile->page_4.fuel_consumption = ui_vars.ui32_wh_x10;
  p_profile->page_4.fuel_consumption = 3000;
`