### PR TITLE
new pwm implementation

### DIFF
--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -66,11 +66,12 @@ to enter and exit **CONFIGURATION MODE**, Press the **ENTER** key for a more tha
 
 ----
 
-* Short press the **PLUS/MINUS** keys to enable/disable garmin control. (The **GREEN** LED will light for 3 seconds to indicate that garmin control is active)
-* Long Press PLUS/MINUS keys\ will enable/disable TSDZ2 motor control(The **RED** LED will light for 3 seconds to indicate that motor control is active)
 * Short press the ENTER key to display configuration options.The **GREEN** LED will light for 3 seconds to indicate that garmin control is active and the **RED** LED will light for 3 seconds to indicate that motor control is active
-* A Long Press of the [**POWER**] button will initate Device Firmware Update (DFU) mode.  The **WHITE** LED will display for 2 seconds, and the board will enter DFU mode.Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
 * Long press the ENTER key to leave **CONFIGURATION**  mode. The **BLUE** LED will light for 3 seconds to indicate you are entering **NORMAL** mode
+* Short press the **PLUS/MINUS** keys to enable/disable garmin control. (The **GREEN** LED will light for 3 seconds to indicate that garmin control is active)
+* Long Press PLUS/MINUS keys will enable/disable TSDZ2 motor control(The **RED** LED will light for 3 seconds to indicate that motor control is active)
+* A Long Press of the [**POWER**] button will initate Device Firmware Update (DFU) mode.  The **GREEN** LED will flash rapidly for 2 seconds, and the board will enter DFU mode.Either the remote or bootloader firmware can be updated to a new version using a provided upgrade packet zip file in DFU mode. For more information click [here](dfu.md).
+
 
 
 ----

--- a/EBike_wireless_remote/documentation/operation.md
+++ b/EBike_wireless_remote/documentation/operation.md
@@ -7,9 +7,8 @@
 1. Ensure that the second wireless board is powered up and connected to the TSDZ2 motor controller. Ensure that the remote has a battery connected and press any button to start the pairing process with the motor controller. When the remote is searching for an ANT connection, the **RED LED** will slowly flash. When a connection is made with the motor, the **BLUE LED** will quickly flash and then go out.
 2. To turn on the motor from the remote control, press and hold the **POWER** key on the remote control. A  **WHITE** LED will start flashing, and will continue flashing until the motor is on, at which time a **BLUE** LED will briefly flash.
 3. press the **PLUS/MINUS** keys briefly to increase/decrease the motor assist level. The **GREEN** LED will briefly flash on every press of the key. There are 7 levels of assist. When you reach level 7 (maximum assist) or level 0 (motor off) the **RED** LED will rapidly flash.
-4. To turn off the motor, press and hold the **POWER** key on the remote control. The **RED** LED will briefly flash, and the motor will turn off. The **BLUE** LED will then flash one flash for every 10% of charge remaining in the battery.(ie:5 flashes=50% charge remaining). 
-5. (Optional step needed you have connected the e-brakes) Depress either the right or left brake lever. The **RED** LED will light and the motor assist will stop. Release the brake lever and the **RED** led will turn off and the motor assist will resume.
-
+4. (Optional step needed you have connected the e-brakes) Depress either the right or left brake lever. The **RED** LED will light and the motor assist will stop. Release the brake lever and the **RED** led will turn off and the motor assist will resume.
+5. To turn off the motor, press and hold the **POWER** key on the remote control. The **RED** LED will briefly flash, and the motor will turn off. The **BLUE** LED will then flash one flash for every 10% of charge remaining in the battery.(ie:5 flashes=50% charge remaining).
 
 ### **That's basically all you need to use the remote for basic operation.**
 
@@ -59,7 +58,7 @@ In **CONFIGURATION MODE**, the remote has a 2 configuration options, namely spec
 
 * The ANT ID allows you to pair the remote to a specific TSDZ2 motor. The default ANT ID of 0 allows the remote to pair with any TSDZ2 motor within range. Any other number will cause the remote to ONLY pair with a motor with the same ANT ID. This is a useful option if you have multiple ebikes. The ANT ID can be changed by a bluetooth connection to the remote.
 * The ANT LEV control options allow you to pair the remote to an ebike alone, (the default option) , a bike computer (like the Garmin Edge series) , or any combination of these devices.
-to enter and exit **CONFIGURATION MODE**, Press the **ENTER** key for a more than 5 seconds. The BLUE LED will light for 3 seconds and quickly flash, followed by a visual display of ANT  options. The RED LED will light for 3 seconds to indicate TSDZ2 motor control is active, followed by the GREEN LED to indicate that control of Garmin bike computers is active <br>
+to enter and exit **CONFIGURATION MODE**, Press the **ENTER** key for a more than 5 seconds. The BLUE LED will light for 1 second and then quickly flash, followed by a visual display of ANT  options. The RED LED will light for 3 seconds to indicate TSDZ2 motor control is active, followed by the GREEN LED to indicate that control of Garmin bike computers is active <br>
 
 ----
 

--- a/EBike_wireless_remote/firmware/.vscode/settings.json
+++ b/EBike_wireless_remote/firmware/.vscode/settings.json
@@ -2,6 +2,7 @@
     "git.ignoreLimitWarning": true,
     "github.gitAuthentication": false,
     "files.associations": {
-      "nrf_assert.h": "c"
+      "nrf_assert.h": "c",
+      "pins.h": "c"
     }
 }

--- a/EBike_wireless_remote/firmware/main.c
+++ b/EBike_wireless_remote/firmware/main.c
@@ -9,10 +9,6 @@
 
 #include <stdio.h>
 #include <stdint.h>
-
-//#include "nrf.h"
-//#include "hardfault.h"
-//#include "app_error.h"
 #include "app_timer.h"
 #include "nrf_pwr_mgmt.h"
 #include "nrf_sdh.h"
@@ -81,9 +77,8 @@ bool searching_flag = false;
 
 #define BUTTON_DETECTION_DELAY APP_TIMER_TICKS(1)            /**< Delay from a GPIOTE event until a button is reported as pushed (in number of timer ticks). */
 #define BUTTON_PRESS_TIMEOUT APP_TIMER_TICKS(60 * 60 * 1000) // 1h to enter low power mode
-//#define BUTTON_PRESS_TIMEOUT APP_TIMER_TICKS(20 * 1000)
-#define BUTTON_LONG_PRESS_TIMEOUT APP_TIMER_TICKS(1000)   // 1 seconds for long press
-#define BUTTON_CONFIG_PRESS_TIMEOUT APP_TIMER_TICKS(5000) // 5 seconds TO ENTER CONFIG MODE
+#define BUTTON_LONG_PRESS_TIMEOUT APP_TIMER_TICKS(1000)      // 1 seconds for long press
+#define BUTTON_CONFIG_PRESS_TIMEOUT APP_TIMER_TICKS(5000)    // 5 seconds TO ENTER CONFIG MODE
 
 #define ANT_Search_TIMEOUT APP_TIMER_TICKS(300) // 300 ms for Ant Search check
 #define DEVICE_NAME "TSDZ2_remote"              /**< Name of device. Will be included in the advertising data. */
@@ -340,7 +335,7 @@ void check_motor_init()
       ////indicate the motor SOC when motor turns on
       if (!searching_flag) //needed if you have a garmin bike computer
       {
-          pwm_fast_flash(LED_B__PIN);
+        pwm_fast_flash(LED_B__PIN);
       }
 
       soc_disp = false;
@@ -799,12 +794,12 @@ static void timer_button_long_press_timeout_handler(void *p_context)
     if (nrf_gpio_pin_read(STANDBY__PIN) == 0)
     {
       //INDICATE ENTERING BOOTLOADER MODE
-      //RED+BLUE MASK
+
       for (int i = 0; i < 6; i++)
       {
         pwm_fast_flash(LED_G__PIN);
       }
-        new_ant_device_id = 0x99;
+      new_ant_device_id = 0x99;
     }
     if (nrf_gpio_pin_read(PLUS__PIN) == 0)
     {
@@ -1236,13 +1231,7 @@ static void lfclk_config(void)
   nrf_drv_clock_lfclk_request(NULL);
 }
 */
-/*
-static void timer_init(void)
-{
-  ret_code_t err_code = app_timer_init();
-  APP_ERROR_CHECK(err_code);
-}
-*/
+
 /**@brief Function for initializing the BLE stack.
  *
  * @details Initializes the SoftDevice and the BLE event interrupt.


### PR DESCRIPTION
@casainho,
here is the PR with the new PWM implementation.
It appears that the remote main.c is conflicting, not sure why, and I can't seem to fix the conflict from my end.
Perhaps you could delete the file and merge this PR?
Anyway, the PR contains the following changes:

1. a new timer based function called pwm_led_on that looks like this:
`void pwm_led_on(void)
{
  //turn on leds based on pwm_led  and pwm_duty_cycle values
  // pwm value:
  // 2: //red
  // 3: //green
  // 4 //blue
  // 5: //Green+RED
  // 6: //BLUE+RED
  // 7) //GREEN + BLUE
  // 9) //GREEN+BLUE+RED
  switch (pwm_led)
  {
  case (2): //red
  case (4): //blue
  case (6): //BLUE+RED
    pwm_duty_cycle = 0.2;
    break;
  case (3): //green
  case (5): //Green+RED
  case (7): //GREEN + BLUE
  case (9): //GREEN+BLUE+RED
    pwm_duty_cycle = 0.1;
    break;
  }
  ret_code_t err_code;
  uint32_t CYCLE_TICKS = APP_TIMER_TICKS(pwm_cycle_time_ms);
  //start the pwm dimming for the selected leds
  err_code = app_timer_start(led_pwm_timer, CYCLE_TICKS, NULL);
  APP_ERROR_CHECK(err_code);
}`
you set up the duty cycle led combo you want and set it going. It turns on the selected LEDs with the desired duty cycle, giving a dimming perception over the pwm timer cycle time of 10ms. (longer cycle times start to create a visible flicker)
The timer based approach works well everywhere, EXCEPT during some button interrupts where fast response is needed. (like assist up/down) if you apply pwm, you can miss button presses.

2. To address the possibility of the button interrupt missing button presses due to the pwm timer priority,  I created two additional pwm non-timer based functions called pwm_notify_flash for quick led single flashes, and pwm_fast_flash to generates  a series of quick flashes (to indicate motor, ANT connection, config mode, etc)

I have adjusted the duty cycle to reduce the brightness for the green led, so now all leds appear equally bright.
@beemac had reqquested I use a yellow LED at motor start up, but no combination of RGB leds gives a convincing yellow on the nrf52840 board. So, I continue to use a white led (all leds on) indicator.

I have tested and all appears good. 
However, we should all test before releasing the code for general use.
