### PR TITLE
removed icon (lower right) from garmin display, added walk mode from wireless remote

### DIFF
--- a/EBike_wireless_TSDZ2/firmware/main.c
+++ b/EBike_wireless_TSDZ2/firmware/main.c
@@ -376,8 +376,8 @@ void ant_lev_evt_handler_pre(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
 
   // 3. lights
   //set by the remote control page 16 command
-  p_profile->common.system_state = p_profile->common.system_state && 0xf7; //lights off
-
+  //p_profile->common.system_state = p_profile->common.system_state && 0xf0; //lights off
+p_profile->common.system_state =  0x00; //lights off
   p_profile->common.system_state |= (mp_ui_vars->ui8_lights << 3);
 
   //4. state of charge

--- a/EBike_wireless_TSDZ2/firmware/main.c
+++ b/EBike_wireless_TSDZ2/firmware/main.c
@@ -509,6 +509,8 @@ void ant_lev_evt_handler_post(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
     if (p_profile->page_16.current_rear_gear == 14)
     {
       // walk mode is activated
+      ui_vars.ui8_walk_assist = 1;
+      
     }
     if (p_profile->page_16.current_rear_gear == 15)
     {
@@ -521,6 +523,7 @@ void ant_lev_evt_handler_post(ant_lev_profile_t *p_profile, ant_lev_evt_t event)
       // disable walk mode
       // disable brakes: be as fast as possible
       nrf_gpio_port_out_set(NRF_P0, 1UL << BRAKE__PIN);
+      ui_vars.ui8_walk_assist = 0;
     }
     if (p_profile->page_16.current_front_gear == 3)
     {


### PR DESCRIPTION
@casainho , I have removed the unwanted icon in the lower right from the garmin display.
@4var1 , the walk mode signal from the wireless remote is a simple on/off flag,  when MINUS is held down ui_vars.ui8_walk_assist = 1;, when released, ui_vars.ui8_walk_assist = 0. My expectation is that walk assist comes on when MINUS is pressed and held down, and stops when the button is released. All walk assist settings should be handled by the android app.

That is not how it is currently working, as I think you have integrated walk assist levels with button changing, and the walk assist is timing out after a few seconds. Could you please have a look at this?